### PR TITLE
Fix required argument validation

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -528,7 +528,7 @@ class Application(object):
 
     def get_default_input_definition(self):
         return InputDefinition([
-            InputArgument('command', InputArgument.REQUIRED, 'The command to execute'),
+            InputArgument('command', InputArgument.REQUIRED, 'The command to execute', is_application_argument=True),
 
             InputOption('--help', '-h', InputOption.VALUE_NONE, 'Display this help message'),
             InputOption('--quiet', '-q', InputOption.VALUE_NONE, 'Do not output any message'),

--- a/cleo/inputs/input.py
+++ b/cleo/inputs/input.py
@@ -64,8 +64,17 @@ class Input(object):
         raise NotImplementedError()
 
     def validate(self):
-        if len(self.get_arguments()) < self.definition.get_argument_required_count():
-            raise MissingArguments('Not enough arguments')
+        current_args = self.get_arguments()
+
+        required_arguments = [
+            argument
+            for argument in self.definition.get_arguments()
+            if argument.is_required() and not argument.is_application_argument()
+        ]
+
+        for argument in required_arguments:
+            if current_args.get(argument.get_name()) is None:
+                raise MissingArguments('Not enough arguments')
 
         self.validate_arguments()
         self.validate_options()

--- a/cleo/inputs/input_argument.py
+++ b/cleo/inputs/input_argument.py
@@ -34,7 +34,7 @@ class InputArgument(object):
     IS_LIST = 4
 
     def __init__(self, name, mode=None,
-                 description='', default=None, validator=None):
+                 description='', default=None, validator=None, is_application_argument=False):
         """
         Constructor
 
@@ -58,6 +58,7 @@ class InputArgument(object):
         self._mode = mode
         self._description = description or ''
         self._validator = VALIDATORS.get(validator)
+        self._is_application_argument = is_application_argument
 
         self.set_default(default)
 
@@ -87,6 +88,15 @@ class InputArgument(object):
         :rtype: bool
         """
         return self.__class__.IS_LIST == (self.__class__.IS_LIST & self._mode)
+
+    def is_application_argument(self):
+        """
+        Returns True if the argument is from application
+
+        :return: True if argument is from application, False otherwise
+        :rtype: bool
+        """
+        return self._is_application_argument
 
     def set_default(self, default=None):
         """


### PR DESCRIPTION
When a required argument is followed by an optional one, then the required argument is not validated. Example:

```python
from cleo import Command


class HelloWorldCommand(Command):
    """
    Hello World Command

    app:hello_world
        {required_arg : Some required argument}
        {non_required_arg? : Some non required argument}
        {--option=5 : Some option that defaults to 5}
    """

    def handle(self):
        self.line('Hello world')
```