### PR TITLE
lint using pep8-naming

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,8 @@ max-line-length = 88
 ignore = E501, E203, W503
 per-file-ignores =
     __init__.py:F401
+    tests/ui/test_exception_trace.py:W291
+    tests/ui/test_table.py:W291
 exclude =
     .git
     __pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
     hooks:
       - id: mypy
         pass_filenames: false
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+        - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,5 @@ repos:
     rev: 4.0.1
     hooks:
         - id: flake8
+          additional_dependencies:
+            - pep8-naming

--- a/cleo/application.py
+++ b/cleo/application.py
@@ -104,7 +104,7 @@ class Application:
 
             return f"<b>{self.display_name}</b>"
 
-        return f"<b>Console</b> application"
+        return "<b>Console</b> application"
 
     @property
     def definition(self) -> Definition:

--- a/cleo/color.py
+++ b/cleo/color.py
@@ -3,7 +3,7 @@ import os
 from typing import List
 from typing import Optional
 
-from .exceptions import ValueException
+from .exceptions import ValueError
 
 
 class Color:
@@ -109,14 +109,14 @@ class Color:
                 color = color[0] * 2 + color[1] * 2 + color[2] * 2
 
             if len(color) != 6:
-                raise ValueException('"{}" is an invalid color'.format(color))
+                raise ValueError('"{}" is an invalid color'.format(color))
 
             return ("4" if background else "3") + self._convert_hex_color_to_ansi(
                 int(color, 16)
             )
 
         if color not in self.COLORS:
-            raise ValueException(
+            raise ValueError(
                 '"{}" is an invalid color. It must be one of {}'.format(
                     color, ", ".join(self.COLORS.keys())
                 )

--- a/cleo/commands/base_command.py
+++ b/cleo/commands/base_command.py
@@ -3,7 +3,7 @@ import inspect
 from typing import TYPE_CHECKING
 from typing import Optional
 
-from cleo.exceptions import CleoException
+from cleo.exceptions import CleoError
 from cleo.io.inputs.definition import Definition
 from cleo.io.io import IO
 
@@ -101,7 +101,7 @@ class BaseCommand(object):
 
         try:
             io.input.bind(self.definition)
-        except CleoException:
+        except CleoError:
             if not self._ignore_validation_errors:
                 raise
 

--- a/cleo/commands/command.py
+++ b/cleo/commands/command.py
@@ -7,8 +7,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from cleo import exceptions
-from cleo.cursor import Cursor
+from cleo.formatters.style import Style
 from cleo.io.inputs.string_input import StringInput
 from cleo.io.io import IO
 from cleo.io.null_io import NullIO

--- a/cleo/commands/completions_command.py
+++ b/cleo/commands/completions_command.py
@@ -7,8 +7,7 @@ import posixpath
 import re
 import subprocess
 
-from ..helpers import argument
-from ..helpers import option
+from .. import helpers
 from .command import Command
 from .completions.templates import TEMPLATES
 
@@ -19,10 +18,12 @@ class CompletionsCommand(Command):
     description = "Generate completion scripts for your shell."
 
     arguments = [
-        argument("shell", "The shell to generate the scripts for.", optional=True)
+        helpers.argument(
+            "shell", "The shell to generate the scripts for.", optional=True
+        )
     ]
     options = [
-        option(
+        helpers.option(
             "alias", None, "Alias for the current command.", flag=False, multiple=True
         )
     ]

--- a/cleo/descriptors/application_description.py
+++ b/cleo/descriptors/application_description.py
@@ -6,7 +6,7 @@ from typing import Union
 
 from cleo.application import Application
 from cleo.commands.command import Command
-from cleo.exceptions import CommandNotFoundException
+from cleo.exceptions import CommandNotFoundError
 
 
 class ApplicationDescription(object):
@@ -38,7 +38,7 @@ class ApplicationDescription(object):
 
     def command(self, name: str) -> Command:
         if name not in self._commands and name not in self._aliases:
-            raise CommandNotFoundException(name)
+            raise CommandNotFoundError(name)
 
         return self._commands.get(name, self._aliases.get(name))
 

--- a/cleo/events/console_error_event.py
+++ b/cleo/events/console_error_event.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 from typing import Optional
 
-from cleo.exceptions import CleoException
+from cleo.exceptions import CleoError
 from cleo.io.io import IO
 
 from .console_event import ConsoleEvent
@@ -31,7 +31,7 @@ class ConsoleErrorEvent(ConsoleEvent):
         if self._exit_code is not None:
             return self._exit_code
 
-        if isinstance(self._error, CleoException) and self._error.exit_code is not None:
+        if isinstance(self._error, CleoError) and self._error.exit_code is not None:
             return self._error.exit_code
 
         return 1

--- a/cleo/exceptions/__init__.py
+++ b/cleo/exceptions/__init__.py
@@ -4,42 +4,42 @@ from typing import Optional
 from cleo._utils import find_similar_names
 
 
-class CleoException(Exception):
+class CleoError(Exception):
 
     exit_code: Optional[int] = None
 
 
-class CleoSimpleException(Exception):
+class CleoSimpleError(Exception):
 
     pass
 
 
-class LogicException(CleoException):
+class LogicError(CleoError):
 
     pass
 
 
-class RuntimeException(CleoException):
+class RuntimeError(CleoError):
 
     pass
 
 
-class ValueException(CleoException):
+class ValueError(CleoError):
 
     pass
 
 
-class MissingArgumentsException(CleoSimpleException):
+class MissingArgumentsError(CleoSimpleError):
 
     pass
 
 
-class NoSuchOptionException(CleoException):
+class NoSuchOptionError(CleoError):
 
     pass
 
 
-class CommandNotFoundException(CleoSimpleException):
+class CommandNotFoundError(CleoSimpleError):
     def __init__(self, name: str, commands: Optional[List[str]] = None) -> None:
         message = 'The command "{}" does not exist.'.format(name)
 
@@ -57,7 +57,7 @@ class CommandNotFoundException(CleoSimpleException):
         super().__init__(message)
 
 
-class NamespaceNotFoundException(CleoSimpleException):
+class NamespaceNotFoundError(CleoSimpleError):
     def __init__(self, name: str, namespaces: Optional[List[str]] = None) -> None:
         message = 'There are no commands in the "{}" namespace.'.format(name)
 

--- a/cleo/formatters/formatter.py
+++ b/cleo/formatters/formatter.py
@@ -4,7 +4,7 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 
-from cleo.exceptions import ValueException
+from cleo.exceptions import ValueError
 
 from .style import Style
 from .style_stack import StyleStack
@@ -74,7 +74,7 @@ class Formatter:
 
     def style(self, name: str) -> Style:
         if not self.has_style(name):
-            raise ValueException(f'Undefined style: "{name}"')
+            raise ValueError(f'Undefined style: "{name}"')
 
         return self._styles[name]
 

--- a/cleo/formatters/style_stack.py
+++ b/cleo/formatters/style_stack.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from cleo.exceptions import ValueException
+from cleo.exceptions import ValueError
 
 from .style import Style
 
@@ -39,4 +39,4 @@ class StyleStack:
 
                 return stacked_style
 
-        raise ValueException("Invalid nested tag found")
+        raise ValueError("Invalid nested tag found")

--- a/cleo/io/inputs/argument.py
+++ b/cleo/io/inputs/argument.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Optional
 
-from cleo.exceptions import LogicException
+from cleo.exceptions import LogicError
 
 
 class Argument:
@@ -45,15 +45,13 @@ class Argument:
 
     def set_default(self, default: Optional[Any] = None) -> None:
         if self._required and default is not None:
-            raise LogicException("Cannot set a default value for required arguments")
+            raise LogicError("Cannot set a default value for required arguments")
 
         if self._is_list:
             if default is None:
                 default = []
             elif not isinstance(default, list):
-                raise LogicException(
-                    "A default value for a list argument must be a list"
-                )
+                raise LogicError("A default value for a list argument must be a list")
 
         self._default = default
 

--- a/cleo/io/inputs/argv_input.py
+++ b/cleo/io/inputs/argv_input.py
@@ -5,8 +5,8 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from cleo.exceptions import NoSuchOptionException
-from cleo.exceptions import RuntimeException
+from cleo.exceptions import NoSuchOptionError
+from cleo.exceptions import RuntimeError
 from cleo.io.inputs.definition import Definition
 
 from .input import Input
@@ -191,7 +191,7 @@ class ArgvInput(Input):
         length = len(name)
         for i in range(length):
             if not self._definition.has_shortcut(name[i]):
-                raise RuntimeException(f'The option "{name[i]}" does not exist')
+                raise RuntimeError(f'The option "{name[i]}" does not exist')
 
             option = self._definition.option_for_shortcut(name[i])
             if option.accepts_value():
@@ -255,11 +255,11 @@ class ArgvInput(Input):
             else:
                 message = 'No arguments expected, got "{}"'.format(token)
 
-            raise RuntimeException(message)
+            raise RuntimeError(message)
 
     def _add_short_option(self, shortcut: str, value: Any) -> None:
         if not self._definition.has_shortcut(shortcut):
-            raise NoSuchOptionException(f'The option "-{shortcut}" does not exist')
+            raise NoSuchOptionError(f'The option "-{shortcut}" does not exist')
 
         self._add_long_option(
             self._definition.option_for_shortcut(shortcut).name, value
@@ -267,12 +267,12 @@ class ArgvInput(Input):
 
     def _add_long_option(self, name: str, value: Any) -> None:
         if not self._definition.has_option(name):
-            raise NoSuchOptionException(f'The option "--{name}" does not exist')
+            raise NoSuchOptionError(f'The option "--{name}" does not exist')
 
         option = self._definition.option(name)
 
         if value is not None and not option.accepts_value():
-            raise RuntimeException(f'The "--{name}" option does not accept a value')
+            raise RuntimeError(f'The "--{name}" option does not accept a value')
 
         if value in ["", None] and option.accepts_value() and self._parsed:
             # If the option accepts a value, either required or optional,
@@ -285,7 +285,7 @@ class ArgvInput(Input):
 
         if value is None:
             if option.requires_value():
-                raise RuntimeException(f'The "--{name}" option requires a value')
+                raise RuntimeError(f'The "--{name}" option requires a value')
 
             if not option.is_list() and option.is_flag():
                 value = True

--- a/cleo/io/inputs/definition.py
+++ b/cleo/io/inputs/definition.py
@@ -6,7 +6,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from cleo.exceptions import LogicException
+from cleo.exceptions import LogicError
 
 from .argument import Argument
 from .option import Option
@@ -94,15 +94,13 @@ class Definition:
 
     def add_argument(self, argument: Argument) -> None:
         if argument.name in self._arguments:
-            raise LogicException(
-                f'An argument with name "{argument.name}" already exists'
-            )
+            raise LogicError(f'An argument with name "{argument.name}" already exists')
 
         if self._has_a_list_argument:
-            raise LogicException("Cannot add an argument after a list argument")
+            raise LogicError("Cannot add an argument after a list argument")
 
         if argument.is_required() and self._has_optional:
-            raise LogicException("Cannot add a required argument after an optional one")
+            raise LogicError("Cannot add a required argument after an optional one")
 
         if argument.is_list():
             self._has_a_list_argument = True
@@ -149,12 +147,12 @@ class Definition:
 
     def add_option(self, option: Option) -> None:
         if option.name in self._options and option != self._options[option.name]:
-            raise LogicException(f'An option named "{option.name}" already exists')
+            raise LogicError(f'An option named "{option.name}" already exists')
 
         if option.shortcut:
             for shortcut in option.shortcut.split("|"):
                 if shortcut in self._shortcuts and option != self._shortcuts[shortcut]:
-                    raise LogicException(
+                    raise LogicError(
                         f'An option with shortcut "{shortcut}" already exists'
                     )
 

--- a/cleo/io/inputs/input.py
+++ b/cleo/io/inputs/input.py
@@ -9,7 +9,6 @@ from typing import Union
 
 from cleo._compat import shell_quote
 from cleo.exceptions import MissingArgumentsException
-from cleo.exceptions import RuntimeException
 from cleo.exceptions import ValueException
 
 from .definition import Definition

--- a/cleo/io/inputs/input.py
+++ b/cleo/io/inputs/input.py
@@ -8,8 +8,8 @@ from typing import TextIO
 from typing import Union
 
 from cleo._compat import shell_quote
-from cleo.exceptions import MissingArgumentsException
-from cleo.exceptions import ValueException
+from cleo.exceptions import MissingArgumentsError
+from cleo.exceptions import ValueError
 
 from .definition import Definition
 
@@ -112,7 +112,7 @@ class Input:
                 missing_arguments.append(argument.name)
 
         if missing_arguments:
-            raise MissingArgumentsException(
+            raise MissingArgumentsError(
                 'Not enough arguments (missing: "{}")'.format(
                     ", ".join(missing_arguments)
                 )
@@ -120,7 +120,7 @@ class Input:
 
     def argument(self, name: str) -> Any:
         if not self._definition.has_argument(name):
-            raise ValueException(f'The argument "{name}" does not exist')
+            raise ValueError(f'The argument "{name}" does not exist')
 
         if name in self._arguments:
             return self._arguments[name]
@@ -129,7 +129,7 @@ class Input:
 
     def set_argument(self, name: str, value: Any) -> None:
         if not self._definition.has_argument(name):
-            raise ValueException(f'The argument "{name}" does not exist')
+            raise ValueError(f'The argument "{name}" does not exist')
 
         self._arguments[name] = value
 
@@ -138,7 +138,7 @@ class Input:
 
     def option(self, name: str) -> Any:
         if not self._definition.has_option(name):
-            raise ValueException(f'The option "--{name}" does not exist')
+            raise ValueError(f'The option "--{name}" does not exist')
 
         if name in self._options:
             return self._options[name]
@@ -147,7 +147,7 @@ class Input:
 
     def set_option(self, name: str, value: Any) -> None:
         if not self._definition.has_option(name):
-            raise ValueException(f'The option "--{name}" does not exist')
+            raise ValueError(f'The option "--{name}" does not exist')
 
         self._options[name] = value
 

--- a/cleo/io/inputs/option.py
+++ b/cleo/io/inputs/option.py
@@ -3,8 +3,8 @@ import re
 from typing import Any
 from typing import Optional
 
-from cleo.exceptions import LogicException
-from cleo.exceptions import ValueException
+from cleo.exceptions import LogicError
+from cleo.exceptions import ValueError
 
 
 class Option:
@@ -26,7 +26,7 @@ class Option:
             name = name[2:]
 
         if not name:
-            raise ValueException("An option name cannot be empty")
+            raise ValueError("An option name cannot be empty")
 
         if shortcut is not None:
             shortcuts = re.split(r"\|-?", shortcut.lstrip("-"))
@@ -34,7 +34,7 @@ class Option:
             shortcut = "|".join(shortcuts)
 
             if not shortcut:
-                raise ValueException("An option shortcut cannot be empty")
+                raise ValueError("An option shortcut cannot be empty")
 
         self._name = name
         self._shortcut = shortcut
@@ -45,7 +45,7 @@ class Option:
         self._default = None
 
         if self._is_list and self._flag:
-            raise LogicException("A flag option cannot be a list as well")
+            raise LogicError("A flag option cannot be a list as well")
 
         self.set_default(default)
 
@@ -79,13 +79,13 @@ class Option:
 
     def set_default(self, default: Optional[Any] = None) -> None:
         if self._flag and default is not None:
-            raise LogicException("A flag option cannot have a default value")
+            raise LogicError("A flag option cannot have a default value")
 
         if self._is_list:
             if default is None:
                 default = []
             elif not isinstance(default, list):
-                raise LogicException("A default value for a list option must be a list")
+                raise LogicError("A default value for a list option must be a list")
 
         if self._flag:
             default = False

--- a/cleo/io/inputs/string_input.py
+++ b/cleo/io/inputs/string_input.py
@@ -1,5 +1,3 @@
-import re
-
 from typing import List
 
 from .argv_input import ArgvInput

--- a/cleo/io/outputs/null_output.py
+++ b/cleo/io/outputs/null_output.py
@@ -1,8 +1,6 @@
 from typing import Iterable
 from typing import Union
 
-from cleo.formatters.formatter import Formatter
-
 from .output import Output
 from .output import Type
 from .output import Verbosity

--- a/cleo/io/outputs/stream_output.py
+++ b/cleo/io/outputs/stream_output.py
@@ -18,6 +18,10 @@ from .output import Verbosity
 if TYPE_CHECKING:
     from .section_output import SectionOutput
 
+FILE_TYPE_CHAR = 0x0002
+FILE_TYPE_REMOTE = 0x8000
+ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
 
 class StreamOutput(Output):
     def __init__(
@@ -112,10 +116,6 @@ class StreamOutput(Output):
             # Activate colors if possible
             import ctypes
             import ctypes.wintypes
-
-            FILE_TYPE_CHAR = 0x0002
-            FILE_TYPE_REMOTE = 0x8000
-            ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 
             kernel32 = ctypes.windll.kernel32
 

--- a/cleo/loaders/factory_command_loader.py
+++ b/cleo/loaders/factory_command_loader.py
@@ -4,7 +4,7 @@ from typing import List
 
 from cleo.commands.command import Command
 
-from ..exceptions import CommandNotFoundException
+from ..exceptions import CommandNotFoundError
 from .command_loader import CommandLoader
 
 
@@ -25,7 +25,7 @@ class FactoryCommandLoader(CommandLoader):
 
     def get(self, name: str) -> Command:
         if name not in self._factories:
-            raise CommandNotFoundException(name)
+            raise CommandNotFoundError(name)
 
         factory = self._factories[name]
 

--- a/cleo/parser.py
+++ b/cleo/parser.py
@@ -1,7 +1,6 @@
 import os
 import re
 
-from collections import namedtuple
 from typing import Any
 from typing import Dict
 from typing import List
@@ -60,7 +59,6 @@ class Parser(object):
         Parse an argument expression.
         """
         description = ""
-        validator = None
 
         if " : " in token:
             token, description = tuple(token.split(" : ", 2))
@@ -73,7 +71,6 @@ class Parser(object):
         matches = re.match(r"(.*)\((.*?)\)", token)
         if matches:
             token = matches.group(1).strip()
-            validator = matches.group(2).strip()
 
         if token.endswith("?*"):
             return Argument(
@@ -115,7 +112,6 @@ class Parser(object):
         Parse an option expression.
         """
         description = ""
-        validator = None
 
         if " : " in token:
             token, description = tuple(token.split(" : ", 2))
@@ -128,7 +124,6 @@ class Parser(object):
         matches = re.match(r"(.*)\((.*?)\)", token)
         if matches:
             token = matches.group(1).strip()
-            validator = matches.group(2).strip()
 
         shortcut = None
 

--- a/cleo/terminal.py
+++ b/cleo/terminal.py
@@ -115,7 +115,7 @@ class Terminal:
 
     @classmethod
     def _get_terminal_size_linux(cls) -> Optional[Tuple[int, int]]:
-        def ioctl_GWINSZ(fd):
+        def ioctl_GWINSZ(fd):  # noqa: N802
             try:
                 import fcntl
                 import termios

--- a/cleo/ui/choice_question.py
+++ b/cleo/ui/choice_question.py
@@ -5,7 +5,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from cleo.exceptions import ValueException
+from cleo.exceptions import ValueError
 from cleo.io.io import IO
 
 from .question import Question
@@ -35,7 +35,7 @@ class SelectChoiceValidator:
         if self._question.supports_multiple_choices():
             # Check for a separated comma values
             if not re.match("^[a-zA-Z0-9_-]+(?:,[a-zA-Z0-9_-]+)*$", selected_choices):
-                raise ValueException(self._question.error_message.format(selected))
+                raise ValueError(self._question.error_message.format(selected))
 
             selected_choices = selected_choices.split(",")
         else:
@@ -50,7 +50,7 @@ class SelectChoiceValidator:
                     results.append(key)
 
             if len(results) > 1:
-                raise ValueException(
+                raise ValueError(
                     "The provided answer is ambiguous. Value should be one of {}.".format(
                         " or ".join(str(r) for r in results)
                     )
@@ -71,7 +71,7 @@ class SelectChoiceValidator:
                     result = False
 
             if result is False:
-                raise ValueException(self._question.error_message.format(value))
+                raise ValueError(self._question.error_message.format(value))
 
             multiselect_choices.append(result)
 

--- a/cleo/ui/table.py
+++ b/cleo/ui/table.py
@@ -1,4 +1,3 @@
-import itertools
 import math
 import re
 
@@ -494,7 +493,7 @@ class Table:
                 )
                 for k, v in unmerged_rows.items():
                     if k in placeholder:
-                        for l, m in unmerged_rows[k].items():
+                        for l, m in unmerged_rows[k].items():  # noqa: E741
                             if l in placeholder[k]:
                                 placeholder[k][l].update(m)
                             else:

--- a/cleo/ui/ui.py
+++ b/cleo/ui/ui.py
@@ -1,7 +1,7 @@
 from typing import Dict
 from typing import List
 
-from cleo.exceptions import ValueException
+from cleo.exceptions import ValueError
 
 from .component import Component
 
@@ -18,17 +18,15 @@ class UI:
 
     def register(self, component: Component) -> None:
         if not isinstance(component, Component):
-            raise ValueException(
-                "A UI component must inherit from the Component class."
-            )
+            raise ValueError("A UI component must inherit from the Component class.")
 
         if not component.name:
-            raise ValueException("A UI component cannot be anonymous.")
+            raise ValueError("A UI component cannot be anonymous.")
 
         self._components[component.name] = component
 
     def component(self, name: str) -> Component:
         if name not in self._components:
-            raise ValueException(f'UI component "{name}" does not exist.')
+            raise ValueError(f'UI component "{name}" does not exist.')
 
         return self._components[name]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,6 @@
 # serve to show the default.
 
 import os
-import sys
-
-import sphinx_rtd_theme
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -186,11 +183,11 @@ htmlhelp_basename = "Cleodoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
-    # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
-    # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'papersize': 'letterpaper',
+    #  The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
+    #  Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/tests/fixtures/foo1_command.py
+++ b/tests/fixtures/foo1_command.py
@@ -1,5 +1,4 @@
 from cleo.commands.command import Command
-from cleo.io.io import IO
 
 
 class Foo1Command(Command):

--- a/tests/fixtures/foo2_command.py
+++ b/tests/fixtures/foo2_command.py
@@ -1,5 +1,4 @@
 from cleo.commands.command import Command
-from cleo.io.io import IO
 
 
 class Foo2Command(Command):

--- a/tests/fixtures/foo_sub_namespaced1_command.py
+++ b/tests/fixtures/foo_sub_namespaced1_command.py
@@ -1,5 +1,4 @@
 from cleo.commands.command import Command
-from cleo.io.io import IO
 
 
 class FooSubNamespaced1Command(Command):

--- a/tests/fixtures/foo_sub_namespaced2_command.py
+++ b/tests/fixtures/foo_sub_namespaced2_command.py
@@ -1,5 +1,4 @@
 from cleo.commands.command import Command
-from cleo.io.io import IO
 
 
 class FooSubNamespaced2Command(Command):

--- a/tests/io/inputs/test_argument.py
+++ b/tests/io/inputs/test_argument.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cleo.exceptions import LogicException
+from cleo.exceptions import LogicError
 from cleo.io.inputs.argument import Argument
 
 
@@ -42,14 +42,14 @@ def test_list_argument():
 
 def test_required_arguments_do_not_support_default_values():
     with pytest.raises(
-        LogicException, match="Cannot set a default value for required arguments"
+        LogicError, match="Cannot set a default value for required arguments"
     ):
         Argument("foo", description="Foo description", default="bar")
 
 
 def test_list_arguments_do_not_support_non_list_default_values():
     with pytest.raises(
-        LogicException, match="A default value for a list argument must be a list"
+        LogicError, match="A default value for a list argument must be a list"
     ):
         Argument(
             "foo",

--- a/tests/io/inputs/test_option.py
+++ b/tests/io/inputs/test_option.py
@@ -1,7 +1,7 @@
 import pytest
 
-from cleo.exceptions import LogicException
-from cleo.exceptions import ValueException
+from cleo.exceptions import LogicError
+from cleo.exceptions import ValueError
 from cleo.io.inputs.option import Option
 
 
@@ -24,17 +24,17 @@ def test_dashed_name():
 
 
 def test_fail_if_name_is_empty():
-    with pytest.raises(ValueException):
+    with pytest.raises(ValueError):
         Option("")
 
 
 def test_fail_if_default_value_provided_for_flag():
-    with pytest.raises(LogicException):
+    with pytest.raises(LogicError):
         Option("option", flag=True, default="default")
 
 
 def test_fail_if_wrong_default_value_for_list_option():
-    with pytest.raises(LogicException):
+    with pytest.raises(LogicError):
         Option("option", flag=False, is_list=True, default="default")
 
 
@@ -57,7 +57,7 @@ def test_multiple_shortcuts():
 
 
 def test_fail_if_shortcut_is_empty():
-    with pytest.raises(ValueException):
+    with pytest.raises(ValueError):
         Option("option", "")
 
 

--- a/tests/loaders/test_factory_command_loader.py
+++ b/tests/loaders/test_factory_command_loader.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cleo.commands.command import Command
-from cleo.exceptions import CommandNotFoundException
+from cleo.exceptions import CommandNotFoundError
 from cleo.loaders.factory_command_loader import FactoryCommandLoader
 
 
@@ -36,7 +36,7 @@ def test_get_invalid_command_raises_error():
         {"foo": lambda: command("foo"), "bar": lambda: command("bar")}
     )
 
-    with pytest.raises(CommandNotFoundException):
+    with pytest.raises(CommandNotFoundError):
         loader.get("baz")
 
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -8,8 +8,8 @@ import pytest
 
 from cleo.application import Application
 from cleo.commands.command import Command
-from cleo.exceptions import CommandNotFoundException
-from cleo.exceptions import NamespaceNotFoundException
+from cleo.exceptions import CommandNotFoundError
+from cleo.exceptions import NamespaceNotFoundError
 from cleo.io.io import IO
 from cleo.io.outputs.stream_output import StreamOutput
 from cleo.testers.application_tester import ApplicationTester
@@ -141,7 +141,7 @@ def test_find_ambiguous_namespace(app: Application):
     app.add(Foo2Command())
 
     with pytest.raises(
-        NamespaceNotFoundException,
+        NamespaceNotFoundError,
         match=r'There are no commands in the "f" namespace\.\n\nDid you mean one of these\?\n    foo\n    foo1',
     ):
         app.find_namespace("f")
@@ -152,7 +152,7 @@ def test_find_invalid_namespace(app: Application):
     app.add(Foo2Command())
 
     with pytest.raises(
-        NamespaceNotFoundException,
+        NamespaceNotFoundError,
         match=r'There are no commands in the "bar" namespace\.',
     ):
         app.find_namespace("bar")
@@ -164,7 +164,7 @@ def test_find_unique_name_but_namespace_name(app: Application):
     app.add(Foo2Command())
 
     with pytest.raises(
-        CommandNotFoundException,
+        CommandNotFoundError,
         match=r'The command "foo1" does not exist\.',
     ):
         app.find("foo1")
@@ -181,7 +181,7 @@ def test_find_ambiguous_command(app: Application):
     app.add(FooCommand())
 
     with pytest.raises(
-        CommandNotFoundException,
+        CommandNotFoundError,
         match=r'The command "foo b" does not exist\.\n\nDid you mean this\?\n    foo bar',
     ):
         app.find("foo b")
@@ -193,7 +193,7 @@ def test_find_ambiguous_command_hidden(app: Application):
     app.add(foo)
 
     with pytest.raises(
-        CommandNotFoundException,
+        CommandNotFoundError,
         match=r'The command "foo b" does not exist\.$',
     ):
         app.find("foo b")
@@ -218,7 +218,7 @@ def test_set_catch_exceptions(app: Application, environ: Dict[str, str]):
 
     app.catch_exceptions(False)
 
-    with pytest.raises(CommandNotFoundException):
+    with pytest.raises(CommandNotFoundError):
         tester.execute("foo", decorated=False)
 
 

--- a/tests/ui/test_choice_question.py
+++ b/tests/ui/test_choice_question.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cleo.exceptions import ValueException
+from cleo.exceptions import ValueError
 from cleo.ui.choice_question import ChoiceQuestion
 
 
@@ -77,13 +77,13 @@ def test_ask_choice(io):
     question = ChoiceQuestion("What is your favourite superhero?", heroes)
     question.set_max_attempts(1)
 
-    with pytest.raises(ValueException) as e:
+    with pytest.raises(ValueError) as e:
         question.ask(io)
 
     assert 'Value "4" is invalid' == str(e.value)
     assert "Superman" == question.ask(io)
 
-    with pytest.raises(ValueException) as e:
+    with pytest.raises(ValueError) as e:
         question.ask(io)
 
     assert 'Value "-2" is invalid' == str(e.value)

--- a/tests/ui/test_exception_trace.py
+++ b/tests/ui/test_exception_trace.py
@@ -468,7 +468,7 @@ def test():
     highlighter = Highlighter()
     lines = highlighter.highlighted_lines(source)
 
-    assert [formatter.format(l) for l in lines] == [
+    assert [formatter.format(line) for line in lines] == [
         "",
         "def test():",
         '    """',


### PR DESCRIPTION
THIS IS A BREAKING CHANGE

use the `pep8-naming` flake8 extension to enforce pep8-compliant names.

stacked on #114 