### PR TITLE
set up mypy hook for incremental adoption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 20.8b1
-    hooks:
-    - id: black
+    - repo: https://github.com/ambv/black
+      rev: 20.8b1
+      hooks:
+          - id: black
+
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: v0.910
+      hooks:
+          - id: mypy
+            pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,46 @@ skip_glob = ["*/setup.py"]
 filter_files = true
 known_first_party = "cleo"
 
+[tool.mypy]
+strict = true
+files = "cleo, tests"
+
+# The following whitelist is used to allow for incremental adoption
+# of Mypy. Modules should be removed from this whitelist as and when
+# their respective type errors have been addressed. No new modules
+# should be added to this whitelist.
+
+[[tool.mypy.overrides]]
+module = [
+    "cleo._utils",
+    "cleo.application",
+    "cleo.descriptors.*",
+    "cleo.color",
+    "cleo.commands.*",
+    "cleo.events.*",
+    "cleo.formatters.*",
+    "cleo.io.*",
+    "cleo.loaders.*",
+    "cleo.parser",
+    "cleo.terminal",
+    "cleo.testers.*",
+    "cleo.ui.*",
+    "tests.commands.*",
+    "tests.conftest",
+    "tests.events.*",
+    "tests.fixtures.*",
+    "tests.formatters.*",
+    "tests.io.*",
+    "tests.loaders.*",
+    "tests.test_application",
+    "tests.test_color",
+    "tests.test_helpers",
+    "tests.test_parser",
+    "tests.testers.*",
+    "tests.ui.*",
+]
+ignore_errors = true
+
 
 [build-system]
 requires = ["poetry-core~=1.0"]


### PR DESCRIPTION
mypy returns whole heap of errors in this repo. this PR sets up an incremental adoption strategy for introducing typing/mypy linting.

Every file that currently produces errors is whitelisted. Over time, this whitelist should be reduced, and eventually removed entirely.

(this is the same strategy being used in `poetry` and `poetry-core`)