### PR TITLE
fix NameError in Command.add_style

### DIFF
--- a/cleo/commands/command.py
+++ b/cleo/commands/command.py
@@ -335,22 +335,11 @@ class Command(BaseCommand):
         """
         Adds a new style
         """
-        style = Style(name)
-        if fg is not None:
-            style.fg(fg)
+        from cleo.formatters.style import Style
+        style = Style(fg, bg, options)
 
-        if bg is not None:
-            style.bg(bg)
-
-        if options is not None:
-            if "bold" in options:
-                style.bold()
-
-            if "underline" in options:
-                style.underlined()
-
-        self._io.output.formatter.add_style(style)
-        self._io.error_output.formatter.add_style(style)
+        self._io.output.formatter.set_style(name, style)
+        self._io.error_output.formatter.set_style(name, style)
 
     def overwrite(self, text):
         """


### PR DESCRIPTION
  NameError

  name 'Style' is not defined

  at ~/.cache/pypoetry/virtualenvs/rlane-pycheck-tEuruZ8u-py3.8/lib/python3.8/site-packages/cleo/commands/command.py:346 in add_style
      342│     def add_style(self, name, fg=None, bg=None, options=None):
      343│         """
      344│         Adds a new style
      345│         """
    → 346│         style = Style(name)
      347│         if fg is not None:
      348│             style.fg(fg)
      349│ 
      350│         if bg is not None:
