### PR TITLE
Decrease default errors verbosity

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -490,7 +490,8 @@ class Application:
         trace = ExceptionTrace(
             error, solution_provider_repository=self._solution_provider_repository
         )
-        trace.render(io.error_output, isinstance(error, CleoSimpleException))
+        simple = not io.is_verbose() or isinstance(error, CleoSimpleException)
+        trace.render(io.error_output, simple)
 
     def _configure_io(self, io: IO) -> None:
         if io.input.has_parameter_option("--ansi", True):

--- a/cleo/ui/exception_trace.py
+++ b/cleo/ui/exception_trace.py
@@ -255,9 +255,10 @@ class ExceptionTrace:
         if simple:
             io.write_line("")
             io.write_line(f"<error>{str(self._exception)}</error>")
-            return
+        else:
+            self._render_exception(io, self._exception)
 
-        return self._render_exception(io, self._exception)
+        self._render_solution(io, self._exception)
 
     def _render_exception(self, io: IO | Output, exception: Exception) -> None:
         from crashtest.inspector import Inspector
@@ -286,7 +287,6 @@ class ExceptionTrace:
         current_frame = inspector.frames[-1]
         self._render_snippet(io, current_frame)
 
-        self._render_solution(io, inspector)
 
     def _render_snippet(self, io: IO | Output, frame: Frame) -> None:
         self._render_line(
@@ -306,12 +306,12 @@ class ExceptionTrace:
         for code_line in code_lines:
             self._render_line(io, code_line, indent=4)
 
-    def _render_solution(self, io: IO | Output, inspector: Inspector) -> None:
+    def _render_solution(self, io: IO | Output, exception: Exception) -> None:
         if self._solution_provider_repository is None:
             return
 
         solutions = self._solution_provider_repository.get_solutions_for_exception(
-            inspector.exception
+            exception
         )
         symbol = "•"
         if not io.supports_utf8():
@@ -348,7 +348,7 @@ class ExceptionTrace:
             stack_frames.append(frame)
 
         remaining_frames_length = len(stack_frames) - 1
-        if io.is_verbose() and remaining_frames_length:
+        if io.is_very_verbose() and remaining_frames_length:
             self._render_line(io, "<fg=yellow>Stack trace</>:", True)
             max_frame_length = len(str(remaining_frames_length))
             frame_collections = stack_frames.compact()

--- a/cleo/ui/exception_trace.py
+++ b/cleo/ui/exception_trace.py
@@ -12,7 +12,6 @@ import tokenize
 from typing import TYPE_CHECKING
 
 from crashtest.frame_collection import FrameCollection
-from crashtest.inspector import Inspector
 
 from cleo.formatters.formatter import Formatter
 
@@ -286,7 +285,6 @@ class ExceptionTrace:
 
         current_frame = inspector.frames[-1]
         self._render_snippet(io, current_frame)
-
 
     def _render_snippet(self, io: IO | Output, frame: Frame) -> None:
         self._render_line(


### PR DESCRIPTION
This shifts error verbosity to reduce terminal output pollution
#### Replaces
https://github.com/python-poetry/poetry/pull/2915
https://github.com/python-poetry/poetry/pull/5559

#### Resolves: 
https://github.com/python-poetry/poetry/issues/2854
https://github.com/python-poetry/poetry/issues/3273
https://github.com/python-poetry/poetry/issues/4014
https://github.com/python-poetry/poetry/issues/5229

#### Current behaviour
- **default**: render error with source reference and solution if present
- `CleoSimpleException`: render it with just a message, never display solution
- `io.is_verbose()`: **default** + full stack trace 

#### New behaviour 
- **default** / `CleoSimpleException`: render error with just a message + solution if present
- `io.is_verbose()`: render error with source reference + solution if present
- `io.is_very_verbose()`: `io.is_verbose()` + full stack trace

#### In other words
- `simple` is enabled by default (whilst supporting solutions)
- `verbose` is now previous default (compact source reference)
- `very_verbose` is now previous `verbose`

#### Showcase
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/36469655/167297577-124629fa-178b-4452-8500-b528ef0456cd.png">
