### PR TITLE
fix: input.stream is null when copied for namespaced commands

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -373,7 +373,9 @@ class Application:
         if io.input.has_parameter_option(["--help", "-h"], True):
             if not name:
                 name = "help"
+                stream = io.input.stream
                 io.set_input(ArgvInput(["console", "help", self._default_command]))
+                io.input.set_stream(stream)
             else:
                 self._want_helps = True
 
@@ -416,7 +418,9 @@ class Application:
             if index is not None:
                 del argv[index + 1 : index + 1 + (len(name.split(" ")) - 1)]
 
+            stream = io.input.stream
             io.set_input(ArgvInput(argv))
+            io.input.set_stream(stream)
 
         exit_code = self._run_command(command, io)
         self._running_command = None

--- a/cleo/application.py
+++ b/cleo/application.py
@@ -373,9 +373,7 @@ class Application:
         if io.input.has_parameter_option(["--help", "-h"], True):
             if not name:
                 name = "help"
-                stream = io.input.stream
                 io.set_input(ArgvInput(["console", "help", self._default_command]))
-                io.input.set_stream(stream)
             else:
                 self._want_helps = True
 

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -39,20 +39,6 @@ class MySecondCommand(Command):
         self.line(",".join(foos))
 
 
-class MyNamespacedCommand(Command):
-    name = "test three"
-    description = "Command testing"
-
-    arguments = [argument("foo", "Bar", multiple=True)]
-
-    def handle(self):
-        foos = self.argument("foo")
-
-        repeat = self.ask("Simon says:")
-        self.line(",".join(foos))
-        self.line(repeat)
-
-
 def test_set_application():
     application = Application()
     command = Command()

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -39,6 +39,19 @@ class MySecondCommand(Command):
         self.line(",".join(foos))
 
 
+class MyNamespacedCommand(Command):
+    name = "test three"
+    description = "Command testing"
+
+    arguments = [argument("foo", "Bar", multiple=True)]
+    def handle(self):
+        foos = self.argument("foo")
+
+        repeat = self.ask("Simon says:")
+        self.line(",".join(foos))
+        self.line(repeat)
+
+
 def test_set_application():
     application = Application()
     command = Command()

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -44,6 +44,7 @@ class MyNamespacedCommand(Command):
     description = "Command testing"
 
     arguments = [argument("foo", "Bar", multiple=True)]
+
     def handle(self):
         foos = self.argument("foo")
 

--- a/tests/fixtures/foo3_command.py
+++ b/tests/fixtures/foo3_command.py
@@ -1,0 +1,15 @@
+from cleo.commands.command import Command
+
+
+class Foo3Command(Command):
+
+    name = "foo3"
+
+    description = "The foo3 bar command"
+
+    aliases = ["foo3"]
+
+    def handle(self) -> int:
+        question = self.ask("echo:")
+        self.line(question)
+        return 0

--- a/tests/fixtures/foo3_command.py
+++ b/tests/fixtures/foo3_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/fixtures/foo_sub_namespaced3_command.py
+++ b/tests/fixtures/foo_sub_namespaced3_command.py
@@ -1,0 +1,16 @@
+from cleo.commands.command import Command
+from cleo.io.io import IO
+
+
+class FooSubNamespaced3Command(Command):
+
+    name = "foo bar"
+
+    description = "The foo bar command"
+
+    aliases = ["foobar"]
+
+    def handle(self) -> int:
+        question = self.ask("")
+        self.line(question)
+        return 0

--- a/tests/fixtures/foo_sub_namespaced3_command.py
+++ b/tests/fixtures/foo_sub_namespaced3_command.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
-from cleo.io.io import IO
 
 
 class FooSubNamespaced3Command(Command):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -358,7 +358,7 @@ def test_run_with_input():
     status_code = tester.execute("foo3", inputs="Hello world!")
 
     assert status_code == 0
-    assert "Hello world!\n" == tester.io.fetch_output()
+    assert tester.io.fetch_output() == "Hello world!\n"
 
 
 def test_run_namespaced_with_input():
@@ -370,4 +370,4 @@ def test_run_namespaced_with_input():
     status_code = tester.execute("foo bar", inputs="Hello world!")
 
     assert status_code == 0
-    assert "Hello world!\n" == tester.io.fetch_output()
+    assert tester.io.fetch_output() == "Hello world!\n"

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -16,9 +16,11 @@ from cleo.io.outputs.stream_output import StreamOutput
 from cleo.testers.application_tester import ApplicationTester
 from tests.fixtures.foo1_command import Foo1Command
 from tests.fixtures.foo2_command import Foo2Command
+from tests.fixtures.foo3_command import Foo3Command
 from tests.fixtures.foo_command import FooCommand
 from tests.fixtures.foo_sub_namespaced1_command import FooSubNamespaced1Command
 from tests.fixtures.foo_sub_namespaced2_command import FooSubNamespaced2Command
+from tests.fixtures.foo_sub_namespaced3_command import FooSubNamespaced3Command
 
 
 FIXTURES_PATH = Path(__file__).parent.joinpath("fixtures")
@@ -345,3 +347,27 @@ def test_run_with_help(tester: ApplicationTester):
         tester.io.fetch_output()
         == FIXTURES_PATH.joinpath("application_run5.txt").read_text()
     )
+
+
+def test_run_with_input():
+    app = Application()
+    command = Foo3Command()
+    app.add(command)
+
+    tester = ApplicationTester(app)
+    status_code = tester.execute("foo3", inputs="Hello world!")
+
+    assert status_code == 0
+    assert "Hello world!\n" == tester.io.fetch_output()
+
+
+def test_run_namespaced_with_input():
+    app = Application()
+    command = FooSubNamespaced3Command()
+    app.add(command)
+
+    tester = ApplicationTester(app)
+    status_code = tester.execute("foo bar", inputs="Hello world!")
+
+    assert status_code == 0
+    assert "Hello world!\n" == tester.io.fetch_output()


### PR DESCRIPTION
There are some cases where `io.input` is recreated, but the `input.stream` attribute is not properly copied over. This fixes an [upstream edge case issue in Poetry](https://github.com/python-poetry/poetry/issues/5633).