### PR TITLE
Simplify flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,20 +1,7 @@
 [flake8]
 max-line-length = 88
-ignore = E501, E203, W503
+extend-ignore = E501, E203
 per-file-ignores =
     __init__.py:F401
     tests/ui/test_exception_trace.py:W291
     tests/ui/test_table.py:W291
-exclude =
-    .git
-    __pycache__
-    setup.py
-    build
-    dist
-    releases
-    .venv
-    .tox
-    .mypy_cache
-    .pytest_cache
-    .vscode
-    .github


### PR DESCRIPTION
the ignore section doesn't appear to be necessary, and many entries are in the default exclude list.
W503 is already in the default ignore list