### PR TITLE
chore: enable pep 563/585

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,8 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+        args: [--add-import, from __future__ import annotations]
+        exclude: ^tests/ui/(helpers|test_exception_trace).py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.910

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,9 @@ repos:
       - id: pyupgrade
         args:
           - --py37-plus
+
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v1.3.3
+    hooks:
+      - id: pycln
+        args: [--all]

--- a/cleo/__init__.py
+++ b/cleo/__init__.py
@@ -1,1 +1,4 @@
+from __future__ import annotations
+
+
 __version__ = "1.0.0a4"

--- a/cleo/_compat.py
+++ b/cleo/_compat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 import subprocess
 import sys

--- a/cleo/_utils.py
+++ b/cleo/_utils.py
@@ -4,7 +4,6 @@ import math
 
 from html.parser import HTMLParser
 from typing import Any
-from typing import List
 
 from pylev import levenshtein
 
@@ -49,7 +48,7 @@ def strip_tags(value: Any) -> str:
     return value
 
 
-def find_similar_names(name: str, names: List[str]) -> List[str]:
+def find_similar_names(name: str, names: list[str]) -> list[str]:
     """
     Finds names similar to a given command name.
     """

--- a/cleo/_utils.py
+++ b/cleo/_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 from html.parser import HTMLParser

--- a/cleo/application.py
+++ b/cleo/application.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/cleo/application.py
+++ b/cleo/application.py
@@ -6,9 +6,6 @@ import sys
 
 from contextlib import suppress
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import List
-from typing import Optional
 from typing import cast
 
 from .commands.command import Command
@@ -62,27 +59,25 @@ class Application:
     def __init__(self, name: str = "console", version: str = "") -> None:
         self._name = name
         self._version = version
-        self._display_name: Optional[str] = None
+        self._display_name: str | None = None
         self._terminal = Terminal()
         self._default_command = "list"
         self._single_command = False
-        self._commands: Dict[str, Command] = {}
+        self._commands: dict[str, Command] = {}
         self._running_command = None
         self._want_helps = False
-        self._definition: Optional[Definition] = None
+        self._definition: Definition | None = None
         self._catch_exceptions = True
         self._auto_exit = True
         self._initialized = False
-        self._ui: Optional[UI] = None
+        self._ui: UI | None = None
 
         # TODO: signals support
-        self._event_dispatcher: Optional[EventDispatcher] = None
+        self._event_dispatcher: EventDispatcher | None = None
 
-        self._command_loader: Optional[CommandLoader] = None
+        self._command_loader: CommandLoader | None = None
 
-        self._solution_provider_repository: Optional[
-            "SolutionProviderRepository"
-        ] = None
+        self._solution_provider_repository: SolutionProviderRepository | None = None
 
     @property
     def name(self) -> str:
@@ -123,7 +118,7 @@ class Application:
         return self._definition
 
     @property
-    def default_commands(self) -> List[Command]:
+    def default_commands(self) -> list[Command]:
         return [HelpCommand(), ListCommand(), CompletionsCommand()]
 
     @property
@@ -138,7 +133,7 @@ class Application:
         return self._ui
 
     @property
-    def event_dispatcher(self) -> Optional[EventDispatcher]:
+    def event_dispatcher(self) -> EventDispatcher | None:
         return self._event_dispatcher
 
     def set_event_dispatcher(self, event_dispatcher: EventDispatcher) -> None:
@@ -175,11 +170,11 @@ class Application:
         return self._single_command
 
     def set_solution_provider_repository(
-        self, solution_provider_repository: "SolutionProviderRepository"
+        self, solution_provider_repository: SolutionProviderRepository
     ) -> None:
         self._solution_provider_repository = solution_provider_repository
 
-    def add(self, command: Command) -> Optional[Command]:
+    def add(self, command: Command) -> Command | None:
         self._init()
 
         command.set_application(self)
@@ -238,7 +233,7 @@ class Application:
             self._command_loader.get(name)
         )
 
-    def get_namespaces(self) -> List[str]:
+    def get_namespaces(self) -> list[str]:
         namespaces = []
         seen = set()
 
@@ -287,7 +282,7 @@ class Application:
 
         raise CommandNotFoundException(name, all_commands)
 
-    def all(self, namespace: Optional[str] = None) -> Dict[str, Command]:
+    def all(self, namespace: str | None = None) -> dict[str, Command]:
         self._init()
 
         if namespace is None:
@@ -320,9 +315,9 @@ class Application:
 
     def run(
         self,
-        input: Optional[Input] = None,
-        output: Optional[Output] = None,
-        error_output: Optional[Output] = None,
+        input: Input | None = None,
+        output: Output | None = None,
+        error_output: Output | None = None,
     ) -> int:
         try:
             io = self.create_io(input, output, error_output)
@@ -470,9 +465,9 @@ class Application:
 
     def create_io(
         self,
-        input: Optional[Input] = None,
-        output: Optional[Output] = None,
-        error_output: Optional[Output] = None,
+        input: Input | None = None,
+        output: Output | None = None,
+        error_output: Output | None = None,
     ) -> IO:
         if input is None:
             input = ArgvInput()
@@ -599,7 +594,7 @@ class Application:
 
         return io.input.first_argument
 
-    def extract_namespace(self, name: str, limit: Optional[int] = None) -> str:
+    def extract_namespace(self, name: str, limit: int | None = None) -> str:
         parts = name.split(" ")[:-1]
 
         if limit is not None:
@@ -612,7 +607,7 @@ class Application:
 
         return UI([ProgressBar()])
 
-    def _extract_all_namespaces(self, name: str) -> List[str]:
+    def _extract_all_namespaces(self, name: str) -> list[str]:
         parts = name.split(" ")[:-1]
         namespaces = []
 

--- a/cleo/color.py
+++ b/cleo/color.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import os
 
-from typing import List
-from typing import Optional
-
 from .exceptions import ValueException
 
 
@@ -44,7 +41,7 @@ class Color:
         self,
         foreground: str = "",
         background: str = "",
-        options: Optional[List[str]] = None,
+        options: list[str] | None = None,
     ) -> None:
         self._foreground = self._parse_color(foreground, False)
         self._background = self._parse_color(background, True)

--- a/cleo/color.py
+++ b/cleo/color.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from typing import List

--- a/cleo/commands/base_command.py
+++ b/cleo/commands/base_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 
 from typing import TYPE_CHECKING

--- a/cleo/commands/base_command.py
+++ b/cleo/commands/base_command.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import inspect
 
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import List
-from typing import Optional
 
 from cleo.exceptions import CleoException
 from cleo.io.inputs.definition import Definition
@@ -18,7 +15,7 @@ if TYPE_CHECKING:
 
 class BaseCommand:
 
-    name: Optional[str] = None
+    name: str | None = None
 
     description = ""
 
@@ -27,14 +24,14 @@ class BaseCommand:
     enabled = True
     hidden = False
 
-    usages: List[str] = []
+    usages: list[str] = []
 
     def __init__(self) -> None:
         self._definition = Definition()
         self._full_definition = None
         self._application = None
         self._ignore_validation_errors = False
-        self._synopsis: Dict[str, str] = {}
+        self._synopsis: dict[str, str] = {}
 
         self.configure()
 
@@ -43,7 +40,7 @@ class BaseCommand:
                 self.usages[i] = f"{self.name} {usage}"
 
     @property
-    def application(self) -> "Application":
+    def application(self) -> Application:
         return self._application
 
     @property
@@ -77,7 +74,7 @@ class BaseCommand:
     def ignore_validation_errors(self) -> None:
         self._ignore_validation_errors = True
 
-    def set_application(self, application: Optional["Application"] = None) -> None:
+    def set_application(self, application: Application | None = None) -> None:
         self._application = application
 
         self._full_definition = None

--- a/cleo/commands/command.py
+++ b/cleo/commands/command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import re
 

--- a/cleo/commands/command.py
+++ b/cleo/commands/command.py
@@ -5,9 +5,6 @@ import re
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import List
-from typing import Optional
-from typing import Union
 
 from cleo.formatters.style import Style
 from cleo.io.inputs.string_input import StringInput
@@ -38,7 +35,7 @@ class Command(BaseCommand):
     commands = []
 
     def __init__(self) -> None:
-        self._io: Optional[IO] = None
+        self._io: IO | None = None
         super().__init__()
 
     @property
@@ -94,7 +91,7 @@ class Command(BaseCommand):
         """
         raise NotImplementedError()
 
-    def call(self, name: str, args: Optional[str] = None) -> int:
+    def call(self, name: str, args: str | None = None) -> int:
         """
         Call another command.
         """
@@ -106,7 +103,7 @@ class Command(BaseCommand):
 
         return self.application._run_command(command, self._io.with_input(input))
 
-    def call_silent(self, name: str, args: Optional[str] = None) -> int:
+    def call_silent(self, name: str, args: str | None = None) -> int:
         """
         Call another command silently.
         """
@@ -144,9 +141,7 @@ class Command(BaseCommand):
 
         return question.ask(self._io)
 
-    def ask(
-        self, question: Union[str, "Question"], default: Optional[Any] = None
-    ) -> Any:
+    def ask(self, question: str | Question, default: Any | None = None) -> Any:
         """
         Prompt the user for input.
         """
@@ -157,9 +152,7 @@ class Command(BaseCommand):
 
         return question.ask(self._io)
 
-    def secret(
-        self, question: Union[str, "Question"], default: Optional[Any] = None
-    ) -> Any:
+    def secret(self, question: str | Question, default: Any | None = None) -> Any:
         """
         Prompt the user for input but hide the answer from the console.
         """
@@ -175,9 +168,9 @@ class Command(BaseCommand):
     def choice(
         self,
         question: str,
-        choices: List[str],
-        default: Optional[Any] = None,
-        attempts: Optional[int] = None,
+        choices: list[str],
+        default: Any | None = None,
+        attempts: int | None = None,
         multiple: bool = False,
     ) -> Any:
         """
@@ -225,7 +218,7 @@ class Command(BaseCommand):
 
         return table
 
-    def table_separator(self) -> "TableSeparator":
+    def table_separator(self) -> TableSeparator:
         """
         Return a TableSeparator instance.
         """
@@ -241,7 +234,7 @@ class Command(BaseCommand):
 
         table.render()
 
-    def write(self, text: str, style: Optional[str] = None) -> None:
+    def write(self, text: str, style: str | None = None) -> None:
         """
         Writes a string without a new line.
         Useful if you want to use overwrite().
@@ -256,7 +249,7 @@ class Command(BaseCommand):
     def line(
         self,
         text: str,
-        style: Optional[str] = None,
+        style: str | None = None,
         verbosity: Verbosity = Verbosity.NORMAL,
     ) -> None:
         """
@@ -272,7 +265,7 @@ class Command(BaseCommand):
     def line_error(
         self,
         text: str,
-        style: Optional[str] = None,
+        style: str | None = None,
         verbosity: Verbosity = Verbosity.NORMAL,
     ) -> None:
         """
@@ -312,7 +305,7 @@ class Command(BaseCommand):
         """
         self.line(text, "question")
 
-    def progress_bar(self, max: int = 0) -> "ProgressBar":
+    def progress_bar(self, max: int = 0) -> ProgressBar:
         """
         Creates a new progress bar
         """
@@ -322,10 +315,10 @@ class Command(BaseCommand):
 
     def progress_indicator(
         self,
-        fmt: Optional[str] = None,
+        fmt: str | None = None,
         interval: int = 100,
-        values: Optional[List[str]] = None,
-    ) -> "ProgressIndicator":
+        values: list[str] | None = None,
+    ) -> ProgressIndicator:
         """
         Creates a new progress indicator.
         """
@@ -337,9 +330,9 @@ class Command(BaseCommand):
         self,
         start_message: str,
         end_message: str,
-        fmt: Optional[str] = None,
+        fmt: str | None = None,
         interval=100,
-        values: Optional[List[str]] = None,
+        values: list[str] | None = None,
     ):
         """
         Automatically spin a progress indicator.
@@ -351,9 +344,9 @@ class Command(BaseCommand):
     def add_style(
         self,
         name: str,
-        fg: Optional[str] = None,
-        bg: Optional[str] = None,
-        options: Optional[List[str]] = None,
+        fg: str | None = None,
+        bg: str | None = None,
+        options: list[str] | None = None,
     ) -> None:
         """
         Adds a new style

--- a/cleo/commands/completions/templates.py
+++ b/cleo/commands/completions/templates.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 BASH_TEMPLATE = """%(function)s()
 {
     local cur script coms opts com

--- a/cleo/commands/completions_command.py
+++ b/cleo/commands/completions_command.py
@@ -7,8 +7,6 @@ import posixpath
 import re
 import subprocess
 
-from typing import Optional
-
 from .. import helpers
 from .command import Command
 from .completions.templates import TEMPLATES
@@ -406,7 +404,7 @@ script. Consult your shells documentation for how to add such directives.
 
         return re.sub("[^A-Za-z0-9_]+", "", name)
 
-    def _zsh_describe(self, value: str, description: Optional[str] = None) -> str:
+    def _zsh_describe(self, value: str, description: str | None = None) -> str:
         value = '"' + value.replace(":", "\\:")
         if description:
             description = re.sub(

--- a/cleo/commands/completions_command.py
+++ b/cleo/commands/completions_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import inspect
 import os

--- a/cleo/commands/help_command.py
+++ b/cleo/commands/help_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.io.inputs.argument import Argument
 
 from .command import Command

--- a/cleo/commands/list_command.py
+++ b/cleo/commands/list_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.io.inputs.argument import Argument
 
 from .command import Command

--- a/cleo/cursor.py
+++ b/cleo/cursor.py
@@ -2,16 +2,14 @@ from __future__ import annotations
 
 import sys
 
-from typing import Optional
 from typing import TextIO
-from typing import Union
 
 from cleo.io.io import IO
 from cleo.io.outputs.output import Output
 
 
 class Cursor:
-    def __init__(self, io: Union[IO, Output], input: Optional[TextIO] = None) -> None:
+    def __init__(self, io: IO | Output, input: TextIO | None = None) -> None:
         if isinstance(io, IO):
             io = io.output
 
@@ -22,57 +20,57 @@ class Cursor:
 
         self._input = input
 
-    def move_up(self, lines: int = 1) -> "Cursor":
+    def move_up(self, lines: int = 1) -> Cursor:
         self._output.write(f"\x1b[{lines}A")
 
         return self
 
-    def move_down(self, lines: int = 1) -> "Cursor":
+    def move_down(self, lines: int = 1) -> Cursor:
         self._output.write(f"\x1b[{lines}B")
 
         return self
 
-    def move_right(self, columns: int = 1) -> "Cursor":
+    def move_right(self, columns: int = 1) -> Cursor:
         self._output.write(f"\x1b[{columns}C")
 
         return self
 
-    def move_left(self, columns: int = 1) -> "Cursor":
+    def move_left(self, columns: int = 1) -> Cursor:
         self._output.write(f"\x1b[{columns}D")
 
         return self
 
-    def move_to_column(self, column: int) -> "Cursor":
+    def move_to_column(self, column: int) -> Cursor:
         self._output.write(f"\x1b[{column}G")
 
         return self
 
-    def move_to_position(self, column: int, row: int) -> "Cursor":
+    def move_to_position(self, column: int, row: int) -> Cursor:
         self._output.write(f"\x1b[{row + 1};{column}H")
 
         return self
 
-    def save_position(self) -> "Cursor":
+    def save_position(self) -> Cursor:
         self._output.write("\x1b7")
 
         return self
 
-    def restore_position(self) -> "Cursor":
+    def restore_position(self) -> Cursor:
         self._output.write("\x1b8")
 
         return self
 
-    def hide(self) -> "Cursor":
+    def hide(self) -> Cursor:
         self._output.write("\x1b[?25l")
 
         return self
 
-    def show(self) -> "Cursor":
+    def show(self) -> Cursor:
         self._output.write("\x1b[?25h\x1b[?0c")
 
         return self
 
-    def clear_line(self) -> "Cursor":
+    def clear_line(self) -> Cursor:
         """
         Clears all the output from the current line.
         """
@@ -80,7 +78,7 @@ class Cursor:
 
         return self
 
-    def clear_line_after(self) -> "Cursor":
+    def clear_line_after(self) -> Cursor:
         """
         Clears all the output from the current line after the current position.
         """
@@ -88,7 +86,7 @@ class Cursor:
 
         return self
 
-    def clear_output(self) -> "Cursor":
+    def clear_output(self) -> Cursor:
         """
         Clears all the output from the cursors' current position
         to the end of the screen.
@@ -97,7 +95,7 @@ class Cursor:
 
         return self
 
-    def clear_screen(self) -> "Cursor":
+    def clear_screen(self) -> Cursor:
         """
         Clears the entire screen.
         """

--- a/cleo/cursor.py
+++ b/cleo/cursor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from typing import Optional

--- a/cleo/descriptors/application_description.py
+++ b/cleo/descriptors/application_description.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 from typing import List
 from typing import Optional

--- a/cleo/descriptors/application_description.py
+++ b/cleo/descriptors/application_description.py
@@ -1,11 +1,5 @@
 from __future__ import annotations
 
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
-
 from cleo.application import Application
 from cleo.commands.command import Command
 from cleo.exceptions import CommandNotFoundException
@@ -18,24 +12,24 @@ class ApplicationDescription:
     def __init__(
         self,
         application: Application,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         show_hidden: bool = False,
     ) -> None:
         self._application: Application = application
         self._namespace = namespace
         self._show_hidden = show_hidden
-        self._namespaces: Dict[str, Dict[str, Union[str, List[Command]]]] = {}
+        self._namespaces: dict[str, dict[str, str | list[Command]]] = {}
         self._commands = {}
         self._aliases = {}
 
         self._inspect_application()
 
     @property
-    def namespaces(self) -> Dict[str, Dict[str, Union[str, List[Command]]]]:
+    def namespaces(self) -> dict[str, dict[str, str | list[Command]]]:
         return self._namespaces
 
     @property
-    def commands(self) -> Dict[str, Command]:
+    def commands(self) -> dict[str, Command]:
         return self._commands
 
     def command(self, name: str) -> Command:
@@ -68,8 +62,8 @@ class ApplicationDescription:
             self._namespaces[namespace] = {"id": namespace, "commands": names}
 
     def _sort_commands(
-        self, commands: Dict[str, Command]
-    ) -> List[Tuple[str, List[Tuple[str, Command]]]]:
+        self, commands: dict[str, Command]
+    ) -> list[tuple[str, list[tuple[str, Command]]]]:
         """
         Sorts command in alphabetical order
         """

--- a/cleo/descriptors/descriptor.py
+++ b/cleo/descriptors/descriptor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 from typing import Optional
 

--- a/cleo/descriptors/descriptor.py
+++ b/cleo/descriptors/descriptor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Optional
 
 from cleo.application import Application
 from cleo.commands.command import Command
@@ -14,7 +13,7 @@ from cleo.io.outputs.output import Type
 
 class Descriptor:
     def __init__(self) -> None:
-        self._io: Optional[IO] = None
+        self._io: IO | None = None
 
     def describe(self, io: IO, obj: Any, **options: Any) -> None:
         self._io = io

--- a/cleo/descriptors/text_descriptor.py
+++ b/cleo/descriptors/text_descriptor.py
@@ -4,9 +4,7 @@ import json
 import re
 
 from typing import Any
-from typing import List
 from typing import Sequence
-from typing import Union
 
 from cleo.application import Application
 from cleo.commands.command import Command
@@ -249,7 +247,7 @@ class TextDescriptor(Descriptor):
 
         return json.dumps(default).replace("\\\\", "\\")
 
-    def _calculate_total_width_for_options(self, options: List[Option]) -> int:
+    def _calculate_total_width_for_options(self, options: list[Option]) -> int:
         total_width = 0
 
         for option in options:
@@ -266,7 +264,7 @@ class TextDescriptor(Descriptor):
 
         return total_width
 
-    def _get_column_width(self, commands: Sequence[Union[Command, str]]) -> int:
+    def _get_column_width(self, commands: Sequence[Command | str]) -> int:
         widths = []
 
         for command in commands:

--- a/cleo/descriptors/text_descriptor.py
+++ b/cleo/descriptors/text_descriptor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import re
 

--- a/cleo/events/console_command_event.py
+++ b/cleo/events/console_command_event.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Optional
 
 from cleo.io.io import IO
 
@@ -21,7 +20,7 @@ class ConsoleCommandEvent(ConsoleEvent):
 
     RETURN_CODE_DISABLED: int = 113
 
-    def __init__(self, command: Optional["Command"], io: IO) -> None:
+    def __init__(self, command: Command | None, io: IO) -> None:
         super().__init__(command, io)
 
         self._command_should_run = True

--- a/cleo/events/console_command_event.py
+++ b/cleo/events/console_command_event.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import Optional
 

--- a/cleo/events/console_error_event.py
+++ b/cleo/events/console_error_event.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import Optional
 

--- a/cleo/events/console_error_event.py
+++ b/cleo/events/console_error_event.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Optional
 
 from cleo.exceptions import CleoException
 from cleo.io.io import IO
@@ -18,11 +17,11 @@ class ConsoleErrorEvent(ConsoleEvent):
     An event triggered when an exception is raised during the execution of a command.
     """
 
-    def __init__(self, command: Optional["Command"], io: IO, error: Exception) -> None:
+    def __init__(self, command: Command | None, io: IO, error: Exception) -> None:
         super().__init__(command, io)
 
         self._error = error
-        self._exit_code: Optional[int] = None
+        self._exit_code: int | None = None
 
     @property
     def error(self) -> Exception:

--- a/cleo/events/console_event.py
+++ b/cleo/events/console_event.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Optional
 
 from cleo.io.io import IO
 
@@ -17,14 +16,14 @@ class ConsoleEvent(Event):
     An event that gives access to the IO of a command.
     """
 
-    def __init__(self, command: Optional["Command"], io: IO) -> None:
+    def __init__(self, command: Command | None, io: IO) -> None:
         super().__init__()
 
         self._command = command
         self._io = io
 
     @property
-    def command(self) -> "Command":
+    def command(self) -> Command:
         return self._command
 
     @property

--- a/cleo/events/console_event.py
+++ b/cleo/events/console_event.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import Optional
 

--- a/cleo/events/console_events.py
+++ b/cleo/events/console_events.py
@@ -1,6 +1,9 @@
 # The COMMAND event allows to attach listeners before any command
 # is executed. It also allows the modification of the command and IO
 # before it's handed to the command.
+from __future__ import annotations
+
+
 COMMAND = "console.command"
 
 # The SIGNAL event allows some actions to be performed after

--- a/cleo/events/console_signal_event.py
+++ b/cleo/events/console_signal_event.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import signal
 
 from typing import TYPE_CHECKING
-from typing import Optional
 
 from cleo.io.io import IO
 
@@ -20,7 +19,7 @@ class ConsoleSignalEvent(ConsoleEvent):
     """
 
     def __init__(
-        self, command: Optional["Command"], io: IO, handling_signal: signal.Signals
+        self, command: Command | None, io: IO, handling_signal: signal.Signals
     ) -> None:
         super().__init__(command, io)
         self._handling_signal = handling_signal

--- a/cleo/events/console_signal_event.py
+++ b/cleo/events/console_signal_event.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import signal
 
 from typing import TYPE_CHECKING

--- a/cleo/events/console_terminate_event.py
+++ b/cleo/events/console_terminate_event.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Optional
 
 from cleo.io.io import IO
 
@@ -17,7 +16,7 @@ class ConsoleTerminateEvent(ConsoleEvent):
     An event triggered by after the execution of a command.
     """
 
-    def __init__(self, command: Optional["Command"], io: IO, exit_code: int) -> None:
+    def __init__(self, command: Command | None, io: IO, exit_code: int) -> None:
         super().__init__(command, io)
 
         self._exit_code = exit_code

--- a/cleo/events/console_terminate_event.py
+++ b/cleo/events/console_terminate_event.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from typing import Optional
 

--- a/cleo/events/event.py
+++ b/cleo/events/event.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Event:
     """
     Event

--- a/cleo/events/event_dispatcher.py
+++ b/cleo/events/event_dispatcher.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
 
 from .event import Event
 
@@ -14,7 +10,7 @@ class EventDispatcher:
         self._listeners = {}
         self._sorted = {}
 
-    def dispatch(self, event: Event, event_name: Optional[str] = None) -> Event:
+    def dispatch(self, event: Event, event_name: str | None = None) -> Event:
         if event_name is None:
             event_name = event.__class__.__name__
 
@@ -26,8 +22,8 @@ class EventDispatcher:
         return event
 
     def get_listeners(
-        self, event_name: Optional[str] = None
-    ) -> Union[List[Callable], Dict[str, Callable]]:
+        self, event_name: str | None = None
+    ) -> list[Callable] | dict[str, Callable]:
         if event_name is not None:
             if event_name not in self._listeners:
                 return []
@@ -43,9 +39,7 @@ class EventDispatcher:
 
         return self._sorted
 
-    def get_listener_priority(
-        self, event_name: str, listener: Callable
-    ) -> Optional[int]:
+    def get_listener_priority(self, event_name: str, listener: Callable) -> int | None:
         if event_name not in self._listeners:
             return
 
@@ -54,7 +48,7 @@ class EventDispatcher:
                 if v == listener:
                     return priority
 
-    def has_listeners(self, event_name: Optional[str] = None) -> bool:
+    def has_listeners(self, event_name: str | None = None) -> bool:
         if event_name is not None:
             if event_name not in self._listeners:
                 return False
@@ -78,7 +72,7 @@ class EventDispatcher:
             del self._sorted[event_name]
 
     def _do_dispatch(
-        self, listeners: List[Callable], event_name: str, event: Event
+        self, listeners: list[Callable], event_name: str, event: Event
     ) -> None:
         for listener in listeners:
             if event.is_propagation_stopped():

--- a/cleo/events/event_dispatcher.py
+++ b/cleo/events/event_dispatcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 from typing import Dict
 from typing import List

--- a/cleo/exceptions/__init__.py
+++ b/cleo/exceptions/__init__.py
@@ -8,7 +8,7 @@ from cleo._utils import find_similar_names
 
 class CleoException(Exception):
 
-    exit_code: Optional[int] = None
+    exit_code: int | None = None
 
 
 class CleoSimpleException(Exception):
@@ -42,7 +42,7 @@ class NoSuchOptionException(CleoException):
 
 
 class CommandNotFoundException(CleoSimpleException):
-    def __init__(self, name: str, commands: Optional[List[str]] = None) -> None:
+    def __init__(self, name: str, commands: list[str] | None = None) -> None:
         message = f'The command "{name}" does not exist.'
 
         if commands:
@@ -60,7 +60,7 @@ class CommandNotFoundException(CleoSimpleException):
 
 
 class NamespaceNotFoundException(CleoSimpleException):
-    def __init__(self, name: str, namespaces: Optional[List[str]] = None) -> None:
+    def __init__(self, name: str, namespaces: list[str] | None = None) -> None:
         message = f'There are no commands in the "{name}" namespace.'
 
         if namespaces:

--- a/cleo/exceptions/__init__.py
+++ b/cleo/exceptions/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Optional
 

--- a/cleo/formatters/formatter.py
+++ b/cleo/formatters/formatter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from typing import Dict

--- a/cleo/formatters/formatter.py
+++ b/cleo/formatters/formatter.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 import re
 
-from typing import Dict
-from typing import Optional
-from typing import Tuple
-
 from cleo.exceptions import ValueException
 
 from .style import Style
@@ -16,13 +12,13 @@ class Formatter:
 
     TAG_REGEX = re.compile(r"(?ix)<(([a-z](?:[^<>]*)) | /([a-z](?:[^<>]*))?)>")
 
-    _inline_styles_cache: Dict[str, Style] = {}
+    _inline_styles_cache: dict[str, Style] = {}
 
     def __init__(
-        self, decorated: bool = False, styles: Optional[Dict[str, Style]] = None
+        self, decorated: bool = False, styles: dict[str, Style] | None = None
     ) -> None:
         self._decorated = decorated
-        self._styles: Dict[str, Style] = {}
+        self._styles: dict[str, Style] = {}
 
         self.set_style("error", Style("red", options=["bold"]))
         self.set_style("info", Style("blue"))
@@ -146,7 +142,7 @@ class Formatter:
 
         return text
 
-    def _create_style_from_string(self, string: str) -> Optional[Style]:
+    def _create_style_from_string(self, string: str) -> Style | None:
         if string in self._styles:
             return self._styles[string]
 
@@ -177,7 +173,7 @@ class Formatter:
 
     def _apply_current_style(
         self, text: str, current: str, width: int, current_line_length: int
-    ) -> Tuple[str, int]:
+    ) -> tuple[str, int]:
         if not text:
             return "", current_line_length
 

--- a/cleo/formatters/style.py
+++ b/cleo/formatters/style.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-from typing import List
-from typing import Optional
-
 from cleo.color import Color
 
 
 class Style:
     def __init__(
         self,
-        foreground: Optional[str] = None,
-        background: Optional["str"] = None,
-        options: Optional[List[str]] = None,
+        foreground: str | None = None,
+        background: str | None = None,
+        options: list[str] | None = None,
     ) -> None:
         self._foreground = foreground or ""
         self._background = background or ""
@@ -19,50 +16,50 @@ class Style:
 
         self._color = Color(self._foreground, self._background, self._options)
 
-    def foreground(self, foreground: str) -> "Style":
+    def foreground(self, foreground: str) -> Style:
         self._color = Color(foreground, self._background, self._options)
         self._foreground = foreground
 
         return self
 
-    def background(self, background: str) -> "Style":
+    def background(self, background: str) -> Style:
         self._color = Color(self._foreground, background, self._options)
         self._background = background
 
         return self
 
-    def bold(self, bold: bool = True) -> "Style":
+    def bold(self, bold: bool = True) -> Style:
         return self.set_option("bold") if bold else self.unset_option("bold")
 
-    def dark(self, dark: bool = True) -> "Style":
+    def dark(self, dark: bool = True) -> Style:
         return self.set_option("dark") if dark else self.unset_option("dark")
 
-    def underlines(self, underlined: bool = True) -> "Style":
+    def underlines(self, underlined: bool = True) -> Style:
         return (
             self.set_option("underline")
             if underlined
             else self.unset_option("underline")
         )
 
-    def italic(self, italic: bool = True) -> "Style":
+    def italic(self, italic: bool = True) -> Style:
         return self.set_option("italic") if italic else self.unset_option("italic")
 
-    def blinking(self, blinking: bool = True) -> "Style":
+    def blinking(self, blinking: bool = True) -> Style:
         return self.set_option("blink") if blinking else self.unset_option("blink")
 
-    def inverse(self, inverse: bool = True) -> "Style":
+    def inverse(self, inverse: bool = True) -> Style:
         return self.set_option("reverse") if inverse else self.unset_option("reverse")
 
-    def hidden(self, hidden: bool = True) -> "Style":
+    def hidden(self, hidden: bool = True) -> Style:
         return self.set_option("conceal") if hidden else self.unset_option("conceal")
 
-    def set_option(self, option: str) -> "Style":
+    def set_option(self, option: str) -> Style:
         self._options.append(option)
         self._color = Color(self._foreground, self._background, self._options)
 
         return self
 
-    def unset_option(self, option: str) -> "Style":
+    def unset_option(self, option: str) -> Style:
         try:
             index = self._options.index(option)
         except IndexError:

--- a/cleo/formatters/style.py
+++ b/cleo/formatters/style.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Optional
 

--- a/cleo/formatters/style_stack.py
+++ b/cleo/formatters/style_stack.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
-from typing import List
-from typing import Optional
-
 from cleo.exceptions import ValueException
 
 from .style import Style
 
 
 class StyleStack:
-    def __init__(self, empty_style: Optional[Style] = None):
+    def __init__(self, empty_style: Style | None = None):
         if empty_style is None:
             empty_style = Style()
 
         self._empty_style = empty_style
-        self._styles: List[Style] = []
+        self._styles: list[Style] = []
 
     @property
     def current(self) -> Style:
@@ -29,7 +26,7 @@ class StyleStack:
     def push(self, style: Style) -> None:
         self._styles.append(style)
 
-    def pop(self, style: Optional[Style] = None) -> Style:
+    def pop(self, style: Style | None = None) -> Style:
         if not self._styles:
             return self._empty_style
 

--- a/cleo/formatters/style_stack.py
+++ b/cleo/formatters/style_stack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Optional
 

--- a/cleo/helpers.py
+++ b/cleo/helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 from typing import Optional
 

--- a/cleo/helpers.py
+++ b/cleo/helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Optional
 
 from cleo.io.inputs.argument import Argument
 from cleo.io.inputs.option import Option
@@ -9,10 +8,10 @@ from cleo.io.inputs.option import Option
 
 def argument(
     name: str,
-    description: Optional[str] = None,
+    description: str | None = None,
     optional: bool = False,
     multiple: bool = False,
-    default: Optional[Any] = None,
+    default: Any | None = None,
 ) -> Argument:
     return Argument(
         name,
@@ -25,12 +24,12 @@ def argument(
 
 def option(
     long_name: str,
-    short_name: Optional[str] = None,
-    description: Optional[str] = None,
+    short_name: str | None = None,
+    description: str | None = None,
     flag: bool = True,
     value_required: bool = True,
     multiple: bool = False,
-    default: Optional[Any] = None,
+    default: Any | None = None,
 ) -> Option:
     return Option(
         long_name,

--- a/cleo/io/buffered_io.py
+++ b/cleo/io/buffered_io.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 from typing import cast
 

--- a/cleo/io/buffered_io.py
+++ b/cleo/io/buffered_io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
 from typing import cast
 
 from .inputs.input import Input
@@ -11,7 +10,7 @@ from .outputs.buffered_output import BufferedOutput
 class BufferedIO(IO):
     def __init__(
         self,
-        input: Optional[Input] = None,
+        input: Input | None = None,
         decorated: bool = False,
         supports_utf8: bool = True,
     ) -> None:

--- a/cleo/io/inputs/argument.py
+++ b/cleo/io/inputs/argument.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 from typing import Optional
 

--- a/cleo/io/inputs/argument.py
+++ b/cleo/io/inputs/argument.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Optional
 
 from cleo.exceptions import LogicException
 
@@ -16,8 +15,8 @@ class Argument:
         name: str,
         required: bool = True,
         is_list: bool = False,
-        description: Optional[str] = None,
-        default: Optional[Any] = None,
+        description: str | None = None,
+        default: Any | None = None,
     ) -> None:
         self._name = name
         self._required = required
@@ -45,7 +44,7 @@ class Argument:
     def is_list(self) -> bool:
         return self._is_list
 
-    def set_default(self, default: Optional[Any] = None) -> None:
+    def set_default(self, default: Any | None = None) -> None:
         if self._required and default is not None:
             raise LogicException("Cannot set a default value for required arguments")
 

--- a/cleo/io/inputs/argv_input.py
+++ b/cleo/io/inputs/argv_input.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import sys
 
 from typing import Any
-from typing import List
-from typing import Optional
-from typing import Union
 
 from cleo.exceptions import NoSuchOptionException
 from cleo.exceptions import RuntimeException
@@ -20,7 +17,7 @@ class ArgvInput(Input):
     """
 
     def __init__(
-        self, argv: Optional[List[str]] = None, definition: Optional[Definition] = None
+        self, argv: list[str] | None = None, definition: Definition | None = None
     ) -> None:
         if argv is None:
             argv = sys.argv
@@ -39,7 +36,7 @@ class ArgvInput(Input):
         super().__init__(definition=definition)
 
     @property
-    def first_argument(self) -> Optional[str]:
+    def first_argument(self) -> str | None:
         is_option = False
 
         for i, token in enumerate(self._tokens):
@@ -80,11 +77,11 @@ class ArgvInput(Input):
         return
 
     @property
-    def script_name(self) -> Optional[str]:
+    def script_name(self) -> str | None:
         return self._script_name
 
     def has_parameter_option(
-        self, values: Union[str, List[str]], only_params: bool = False
+        self, values: str | list[str], only_params: bool = False
     ) -> bool:
         """
         Returns true if the raw parameters (not parsed) contain a value.
@@ -112,7 +109,7 @@ class ArgvInput(Input):
 
     def parameter_option(
         self,
-        values: Union[str, List[str]],
+        values: str | list[str],
         default: Any = False,
         only_params: bool = False,
     ) -> Any:
@@ -145,7 +142,7 @@ class ArgvInput(Input):
 
         return False
 
-    def _set_tokens(self, tokens: List[str]) -> None:
+    def _set_tokens(self, tokens: list[str]) -> None:
         self._tokens = tokens
 
     def _parse(self) -> None:

--- a/cleo/io/inputs/argv_input.py
+++ b/cleo/io/inputs/argv_input.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from typing import Any

--- a/cleo/io/inputs/definition.py
+++ b/cleo/io/inputs/definition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from typing import Any

--- a/cleo/io/inputs/definition.py
+++ b/cleo/io/inputs/definition.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 import sys
 
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
 from typing import Sequence
-from typing import Union
 
 from cleo.exceptions import LogicException
 
@@ -20,15 +16,13 @@ class Definition:
     A Definition represents a set of command line arguments and options.
     """
 
-    def __init__(
-        self, definition: Optional[Sequence[Union[Argument, Option]]] = None
-    ) -> None:
-        self._arguments: Dict[str, Argument] = {}
+    def __init__(self, definition: Sequence[Argument | Option] | None = None) -> None:
+        self._arguments: dict[str, Argument] = {}
         self._required_count = 0
         self._has_a_list_argument = False
         self._has_optional = False
-        self._options: Dict[str, Option] = {}
-        self._shortcuts: Dict[str, str] = {}
+        self._options: dict[str, Option] = {}
+        self._shortcuts: dict[str, str] = {}
 
         if definition is None:
             definition = []
@@ -36,7 +30,7 @@ class Definition:
         self.set_definition(definition)
 
     @property
-    def arguments(self) -> List[Argument]:
+    def arguments(self) -> list[Argument]:
         return list(self._arguments.values())
 
     @property
@@ -51,7 +45,7 @@ class Definition:
         return self._required_count
 
     @property
-    def argument_defaults(self) -> Dict[str, Any]:
+    def argument_defaults(self) -> dict[str, Any]:
         values = {}
 
         for argument in self._arguments.values():
@@ -60,18 +54,18 @@ class Definition:
         return values
 
     @property
-    def options(self) -> List[Option]:
+    def options(self) -> list[Option]:
         return list(self._options.values())
 
     @property
-    def option_defaults(self) -> Dict[str, Any]:
+    def option_defaults(self) -> dict[str, Any]:
         values = {}
         for option in self._options.values():
             values[option.name] = option.default
 
         return values
 
-    def set_definition(self, definition: Sequence[Union[Argument, Option]]) -> None:
+    def set_definition(self, definition: Sequence[Argument | Option]) -> None:
         arguments = []
         options = []
 
@@ -84,14 +78,14 @@ class Definition:
         self.set_arguments(arguments)
         self.set_options(options)
 
-    def set_arguments(self, arguments: List[Argument]) -> None:
+    def set_arguments(self, arguments: list[Argument]) -> None:
         self._arguments = {}
         self._required_count = 0
         self._has_a_list_argument = False
         self._has_optional = False
         self.add_arguments(arguments)
 
-    def add_arguments(self, arguments: List[Argument]) -> None:
+    def add_arguments(self, arguments: list[Argument]) -> None:
         for argument in arguments:
             self.add_argument(argument)
 
@@ -117,7 +111,7 @@ class Definition:
 
         self._arguments[argument.name] = argument
 
-    def argument(self, name: Union[str, int]) -> Argument:
+    def argument(self, name: str | int) -> Argument:
         if not self.has_argument(name):
             raise ValueError(f'The "{name}" argument does not exist')
 
@@ -128,7 +122,7 @@ class Definition:
 
         return arguments[name]
 
-    def has_argument(self, name: Union[str, int]) -> bool:
+    def has_argument(self, name: str | int) -> bool:
         if isinstance(name, int):
             arguments = list(self._arguments.values())
         else:
@@ -141,12 +135,12 @@ class Definition:
 
         return True
 
-    def set_options(self, options: List[Option]) -> None:
+    def set_options(self, options: list[Option]) -> None:
         self._options = {}
         self._shortcuts = {}
         self.add_options(options)
 
-    def add_options(self, options: List[Option]) -> None:
+    def add_options(self, options: list[Option]) -> None:
         for option in options:
             self.add_option(option)
 

--- a/cleo/io/inputs/input.py
+++ b/cleo/io/inputs/input.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from typing import Any

--- a/cleo/io/inputs/input.py
+++ b/cleo/io/inputs/input.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 import re
 
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
 from typing import TextIO
-from typing import Union
 
 from cleo._compat import shell_quote
 from cleo.exceptions import MissingArgumentsException
@@ -21,7 +17,7 @@ class Input:
     This class is the base class for concrete Input implementations.
     """
 
-    def __init__(self, definition: Optional[Definition] = None) -> None:
+    def __init__(self, definition: Definition | None = None) -> None:
         self._definition = None
         self._stream = None
         self._options = {}
@@ -35,11 +31,11 @@ class Input:
             self.validate()
 
     @property
-    def arguments(self) -> Dict[str, Any]:
+    def arguments(self) -> dict[str, Any]:
         return {**self._definition.argument_defaults, **self._arguments}
 
     @property
-    def options(self) -> Dict[str, Any]:
+    def options(self) -> dict[str, Any]:
         return {**self._definition.option_defaults, **self._options}
 
     @property
@@ -47,17 +43,17 @@ class Input:
         return self._stream
 
     @property
-    def first_argument(self) -> Optional[str]:
+    def first_argument(self) -> str | None:
         """
         Returns the first argument from the raw parameters (not parsed).
         """
         raise NotImplementedError()
 
     @property
-    def script_name(self) -> Optional[str]:
+    def script_name(self) -> str | None:
         raise NotImplementedError()
 
-    def read(self, length: int, default: Optional[str] = None) -> str:
+    def read(self, length: int, default: str | None = None) -> str:
         """
         Reads the given amount of characters from the input stream.
         """
@@ -66,9 +62,7 @@ class Input:
 
         return self._stream.read(length)
 
-    def read_line(
-        self, length: Optional[int] = None, default: Optional[str] = None
-    ) -> str:
+    def read_line(self, length: int | None = None, default: str | None = None) -> str:
         """
         Reads a line from the input stream.
         """
@@ -166,7 +160,7 @@ class Input:
         self._stream = stream
 
     def has_parameter_option(
-        self, values: Union[str, List[str]], only_params: bool = False
+        self, values: str | list[str], only_params: bool = False
     ) -> bool:
         """
         Returns true if the raw parameters (not parsed) contain a value.
@@ -175,7 +169,7 @@ class Input:
 
     def parameter_option(
         self,
-        values: Union[str, List[str]],
+        values: str | list[str],
         only_params: bool = False,
         default: Any = False,
     ) -> Any:

--- a/cleo/io/inputs/option.py
+++ b/cleo/io/inputs/option.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 
 from typing import Any
-from typing import Optional
 
 from cleo.exceptions import LogicException
 from cleo.exceptions import ValueException
@@ -17,12 +16,12 @@ class Option:
     def __init__(
         self,
         name: str,
-        shortcut: Optional[str] = None,
+        shortcut: str | None = None,
         flag: bool = True,
         requires_value: bool = True,
         is_list: bool = False,
-        description: Optional[str] = None,
-        default: Optional[Any] = None,
+        description: str | None = None,
+        default: Any | None = None,
     ) -> None:
         if name.startswith("--"):
             name = name[2:]
@@ -56,7 +55,7 @@ class Option:
         return self._name
 
     @property
-    def shortcut(self) -> Optional[str]:
+    def shortcut(self) -> str | None:
         return self._shortcut
 
     @property
@@ -64,7 +63,7 @@ class Option:
         return self._description
 
     @property
-    def default(self) -> Optional[Any]:
+    def default(self) -> Any | None:
         return self._default
 
     def is_flag(self) -> bool:
@@ -79,7 +78,7 @@ class Option:
     def is_list(self) -> bool:
         return self._is_list
 
-    def set_default(self, default: Optional[Any] = None) -> None:
+    def set_default(self, default: Any | None = None) -> None:
         if self._flag and default is not None:
             raise LogicException("A flag option cannot have a default value")
 

--- a/cleo/io/inputs/option.py
+++ b/cleo/io/inputs/option.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from typing import Any

--- a/cleo/io/inputs/string_input.py
+++ b/cleo/io/inputs/string_input.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 from .argv_input import ArgvInput
 from .token_parser import TokenParser
 
@@ -16,5 +14,5 @@ class StringInput(ArgvInput):
 
         self._set_tokens(self._tokenize(input))
 
-    def _tokenize(self, input: str) -> List[str]:
+    def _tokenize(self, input: str) -> list[str]:
         return TokenParser().parse(input)

--- a/cleo/io/inputs/string_input.py
+++ b/cleo/io/inputs/string_input.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 from .argv_input import ArgvInput

--- a/cleo/io/inputs/token_parser.py
+++ b/cleo/io/inputs/token_parser.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-from typing import Optional
-
 
 class TokenParser:
     """
@@ -12,10 +9,10 @@ class TokenParser:
     def __init__(self) -> None:
         self._string: str = ""
         self._cursor: int = 0
-        self._current: Optional[str] = None
-        self._next_: Optional[str] = None
+        self._current: str | None = None
+        self._next_: str | None = None
 
-    def parse(self, string: str) -> List[str]:
+    def parse(self, string: str) -> list[str]:
         self._string = string
         self._cursor = 0
         self._current = None
@@ -30,7 +27,7 @@ class TokenParser:
 
         return tokens
 
-    def _parse(self) -> List[str]:
+    def _parse(self) -> list[str]:
         tokens = []
 
         while self._is_valid():

--- a/cleo/io/inputs/token_parser.py
+++ b/cleo/io/inputs/token_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Optional
 

--- a/cleo/io/io.py
+++ b/cleo/io/io.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from typing import Iterable
-from typing import Optional
-from typing import Union
 
 from .inputs.input import Input
 from .outputs.output import Output
@@ -29,15 +27,13 @@ class IO:
     def error_output(self) -> Output:
         return self._error_output
 
-    def read(self, length: int, default: Optional[str] = None) -> str:
+    def read(self, length: int, default: str | None = None) -> str:
         """
         Reads the given amount of characters from the input stream.
         """
         return self._input.read(length, default=default)
 
-    def read_line(
-        self, length: Optional[int] = None, default: Optional[str] = None
-    ) -> str:
+    def read_line(self, length: int | None = None, default: str | None = None) -> str:
         """
         Reads a line from the input stream.
         """
@@ -45,7 +41,7 @@ class IO:
 
     def write_line(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         verbosity: Verbosity = Verbosity.NORMAL,
         type: OutputType = OutputType.NORMAL,
     ) -> None:
@@ -53,7 +49,7 @@ class IO:
 
     def write(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         new_line: bool = False,
         verbosity: Verbosity = Verbosity.NORMAL,
         type: OutputType = OutputType.NORMAL,
@@ -62,7 +58,7 @@ class IO:
 
     def write_error_line(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         verbosity: Verbosity = Verbosity.NORMAL,
         type: OutputType = OutputType.NORMAL,
     ) -> None:
@@ -70,7 +66,7 @@ class IO:
 
     def write_error(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         new_line: bool = False,
         verbosity: Verbosity = Verbosity.NORMAL,
         type: OutputType = OutputType.NORMAL,
@@ -79,7 +75,7 @@ class IO:
             messages, new_line=new_line, verbosity=verbosity, type=type
         )
 
-    def overwrite(self, messages: Union[str, Iterable[str]]) -> None:
+    def overwrite(self, messages: str | Iterable[str]) -> None:
         from cleo.cursor import Cursor
 
         cursor = Cursor(self._output)
@@ -87,7 +83,7 @@ class IO:
         cursor.clear_line()
         self.write(messages)
 
-    def overwrite_error(self, messages: Union[str, Iterable[str]]) -> None:
+    def overwrite_error(self, messages: str | Iterable[str]) -> None:
         from cleo.cursor import Cursor
 
         cursor = Cursor(self._error_output)
@@ -130,7 +126,7 @@ class IO:
     def set_input(self, input: Input) -> None:
         self._input = input
 
-    def with_input(self, input: Input) -> "IO":
+    def with_input(self, input: Input) -> IO:
         return self.__class__(input, self._output, self._error_output)
 
     def remove_format(self, text: str) -> str:

--- a/cleo/io/io.py
+++ b/cleo/io/io.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Iterable
 from typing import Optional
 from typing import Union

--- a/cleo/io/null_io.py
+++ b/cleo/io/null_io.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from .inputs.input import Input

--- a/cleo/io/null_io.py
+++ b/cleo/io/null_io.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from .inputs.input import Input
 from .inputs.string_input import StringInput
 from .io import IO
@@ -9,7 +7,7 @@ from .outputs.null_output import NullOutput
 
 
 class NullIO(IO):
-    def __init__(self, input: Optional[Input] = None) -> None:
+    def __init__(self, input: Input | None = None) -> None:
         if input is None:
             input = StringInput("")
 

--- a/cleo/io/outputs/buffered_output.py
+++ b/cleo/io/outputs/buffered_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import StringIO
 
 from .output import Output

--- a/cleo/io/outputs/null_output.py
+++ b/cleo/io/outputs/null_output.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Iterable
-from typing import Union
 
 from .output import Output
 from .output import Type
@@ -39,7 +38,7 @@ class NullOutput(Output):
 
     def write_line(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         verbosity: Verbosity = Verbosity.NORMAL,
         type: Type = Type.NORMAL,
     ) -> None:
@@ -47,7 +46,7 @@ class NullOutput(Output):
 
     def write(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         new_line: bool = False,
         verbosity: Verbosity = Verbosity.NORMAL,
         type: Type = Type.NORMAL,

--- a/cleo/io/outputs/null_output.py
+++ b/cleo/io/outputs/null_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Iterable
 from typing import Union
 

--- a/cleo/io/outputs/output.py
+++ b/cleo/io/outputs/output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import TYPE_CHECKING
 from typing import Iterable

--- a/cleo/io/outputs/output.py
+++ b/cleo/io/outputs/output.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 from typing import Iterable
-from typing import List
-from typing import Optional
-from typing import Union
 
 from cleo._utils import strip_tags
 from cleo.formatters.formatter import Formatter
@@ -36,7 +33,7 @@ class Output:
         self,
         verbosity: Verbosity = Verbosity.NORMAL,
         decorated: bool = False,
-        formatter: Optional[Formatter] = None,
+        formatter: Formatter | None = None,
     ) -> None:
         self._verbosity: Verbosity = verbosity
         if formatter is None:
@@ -45,7 +42,7 @@ class Output:
         self._formatter = formatter
         self._formatter.decorated(decorated)
 
-        self._section_outputs: List[SectionOutput] = []
+        self._section_outputs: list[SectionOutput] = []
 
     @property
     def formatter(self) -> Formatter:
@@ -87,7 +84,7 @@ class Output:
 
     def write_line(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         verbosity: Verbosity = Verbosity.NORMAL,
         type: Type = Type.NORMAL,
     ) -> None:
@@ -95,7 +92,7 @@ class Output:
 
     def write(
         self,
-        messages: Union[str, Iterable[str]],
+        messages: str | Iterable[str],
         new_line: bool = False,
         verbosity: Verbosity = Verbosity.NORMAL,
         type: Type = Type.NORMAL,
@@ -120,7 +117,7 @@ class Output:
     def remove_format(self, text: str) -> str:
         return self.formatter.remove_format(text)
 
-    def section(self) -> "SectionOutput":
+    def section(self) -> SectionOutput:
         raise NotImplementedError()
 
     def _write(self, message: str, new_line: bool = False) -> None:

--- a/cleo/io/outputs/section_output.py
+++ b/cleo/io/outputs/section_output.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import math
 
-from typing import List
-from typing import Optional
 from typing import TextIO
 
 from cleo.formatters.formatter import Formatter
@@ -17,16 +15,16 @@ class SectionOutput(StreamOutput):
     def __init__(
         self,
         stream: TextIO,
-        sections: List["SectionOutput"],
+        sections: list[SectionOutput],
         verbosity: Verbosity = Verbosity.NORMAL,
-        decorated: Optional[bool] = None,
-        formatter: Optional[Formatter] = None,
+        decorated: bool | None = None,
+        formatter: Formatter | None = None,
     ) -> None:
         super().__init__(
             stream, verbosity=verbosity, decorated=decorated, formatter=formatter
         )
 
-        self._content: List[str] = []
+        self._content: list[str] = []
         self._lines = 0
         sections.insert(0, self)
         self._sections = sections
@@ -40,7 +38,7 @@ class SectionOutput(StreamOutput):
     def lines(self) -> int:
         return self._lines
 
-    def clear(self, lines: Optional[int] = None) -> None:
+    def clear(self, lines: int | None = None) -> None:
         if not self._content or not self.is_decorated():
             return
 

--- a/cleo/io/outputs/section_output.py
+++ b/cleo/io/outputs/section_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 
 from typing import List

--- a/cleo/io/outputs/stream_output.py
+++ b/cleo/io/outputs/stream_output.py
@@ -8,7 +8,6 @@ import platform
 import sys
 
 from typing import TYPE_CHECKING
-from typing import Optional
 from typing import TextIO
 
 from cleo.formatters.formatter import Formatter
@@ -26,8 +25,8 @@ class StreamOutput(Output):
         self,
         stream: TextIO,
         verbosity: Verbosity = Verbosity.NORMAL,
-        decorated: Optional[bool] = None,
-        formatter: Optional[Formatter] = None,
+        decorated: bool | None = None,
+        formatter: Formatter | None = None,
     ) -> None:
         self._stream = stream
         self._supports_utf8 = None
@@ -64,7 +63,7 @@ class StreamOutput(Output):
     def flush(self) -> None:
         self._stream.flush()
 
-    def section(self) -> "SectionOutput":
+    def section(self) -> SectionOutput:
         from .section_output import SectionOutput
 
         return SectionOutput(

--- a/cleo/io/outputs/stream_output.py
+++ b/cleo/io/outputs/stream_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import codecs
 import io
 import locale

--- a/cleo/loaders/command_loader.py
+++ b/cleo/loaders/command_loader.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import List
-
 from cleo.commands.command import Command
 
 
 class CommandLoader:
     @property
-    def names(self) -> List[str]:
+    def names(self) -> list[str]:
         """
         All registered command names.
         """

--- a/cleo/loaders/command_loader.py
+++ b/cleo/loaders/command_loader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 from cleo.commands.command import Command

--- a/cleo/loaders/factory_command_loader.py
+++ b/cleo/loaders/factory_command_loader.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from typing import Callable
-from typing import Dict
-from typing import List
 
 from cleo.commands.command import Command
 
@@ -18,11 +16,11 @@ class FactoryCommandLoader(CommandLoader):
     A simple command loader using factories to instantiate commands lazily.
     """
 
-    def __init__(self, factories: Dict[str, Factory]) -> None:
+    def __init__(self, factories: dict[str, Factory]) -> None:
         self._factories = factories
 
     @property
-    def names(self) -> List[str]:
+    def names(self) -> list[str]:
         return list(self._factories.keys())
 
     def has(self, name: str) -> bool:

--- a/cleo/loaders/factory_command_loader.py
+++ b/cleo/loaders/factory_command_loader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 from typing import Dict
 from typing import List

--- a/cleo/parser.py
+++ b/cleo/parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 

--- a/cleo/parser.py
+++ b/cleo/parser.py
@@ -4,8 +4,6 @@ import os
 import re
 
 from typing import Any
-from typing import Dict
-from typing import List
 
 from cleo.io.inputs.argument import Argument
 from cleo.io.inputs.option import Option
@@ -13,11 +11,11 @@ from cleo.io.inputs.option import Option
 
 class Parser:
     @classmethod
-    def parse(cls, expression: str) -> Dict[str, Any]:
+    def parse(cls, expression: str) -> dict[str, Any]:
         """
         Parse the given console command definition into a dict.
         """
-        parsed: Dict[str, Any] = {"name": None, "arguments": [], "options": []}
+        parsed: dict[str, Any] = {"name": None, "arguments": [], "options": []}
 
         if not expression.strip():
             raise ValueError("Console command signature is empty.")
@@ -40,7 +38,7 @@ class Parser:
         return parsed
 
     @classmethod
-    def _parameters(cls, tokens: List[str]) -> Dict[str, Any]:
+    def _parameters(cls, tokens: list[str]) -> dict[str, Any]:
         """
         Extract all of the parameters from the tokens.
         """

--- a/cleo/terminal.py
+++ b/cleo/terminal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import shlex

--- a/cleo/terminal.py
+++ b/cleo/terminal.py
@@ -6,9 +6,6 @@ import shlex
 import struct
 import subprocess
 
-from typing import Optional
-from typing import Tuple
-
 
 class Terminal:
     """
@@ -64,7 +61,7 @@ class Terminal:
         cls._width, cls._height = dimensions
 
     @classmethod
-    def _get_terminal_size_windows(cls) -> Optional[Tuple[int, int]]:
+    def _get_terminal_size_windows(cls) -> tuple[int, int] | None:
         try:
             from ctypes import create_string_buffer
             from ctypes import windll
@@ -96,7 +93,7 @@ class Terminal:
             return
 
     @classmethod
-    def _get_terminal_size_tput(cls) -> Optional[Tuple[int, int]]:
+    def _get_terminal_size_tput(cls) -> tuple[int, int] | None:
         # get terminal width
         # src: http://stackoverflow.com/questions/263890/how-do-i-find-the-width-height-of-a-terminal-window
         try:
@@ -116,7 +113,7 @@ class Terminal:
             pass
 
     @classmethod
-    def _get_terminal_size_linux(cls) -> Optional[Tuple[int, int]]:
+    def _get_terminal_size_linux(cls) -> tuple[int, int] | None:
         def ioctl_GWINSZ(fd):
             try:
                 import fcntl

--- a/cleo/testers/application_tester.py
+++ b/cleo/testers/application_tester.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import StringIO
 from typing import Optional
 

--- a/cleo/testers/application_tester.py
+++ b/cleo/testers/application_tester.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from io import StringIO
-from typing import Optional
 
 from cleo.application import Application
 from cleo.io.buffered_io import BufferedIO
@@ -34,10 +33,10 @@ class ApplicationTester:
 
     def execute(
         self,
-        args: Optional[str] = "",
-        inputs: Optional[str] = None,
-        interactive: Optional[bool] = None,
-        verbosity: Optional[Verbosity] = None,
+        args: str | None = "",
+        inputs: str | None = None,
+        interactive: bool | None = None,
+        verbosity: Verbosity | None = None,
         decorated: bool = False,
         supports_utf8: bool = True,
     ) -> int:

--- a/cleo/testers/command_tester.py
+++ b/cleo/testers/command_tester.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from io import StringIO
-from typing import Optional
 
 from cleo.commands.command import Command
 from cleo.io.buffered_io import BufferedIO
@@ -35,11 +34,11 @@ class CommandTester:
 
     def execute(
         self,
-        args: Optional[str] = "",
-        inputs: Optional[str] = None,
-        interactive: Optional[bool] = None,
-        verbosity: Optional[Verbosity] = None,
-        decorated: Optional[bool] = None,
+        args: str | None = "",
+        inputs: str | None = None,
+        interactive: bool | None = None,
+        verbosity: Verbosity | None = None,
+        decorated: bool | None = None,
         supports_utf8: bool = True,
     ) -> int:
         """

--- a/cleo/testers/command_tester.py
+++ b/cleo/testers/command_tester.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import StringIO
 from typing import Optional
 

--- a/cleo/ui/choice_question.py
+++ b/cleo/ui/choice_question.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import re
 
 from typing import Any
-from typing import List
-from typing import Optional
-from typing import Union
 
 from cleo.exceptions import ValueException
 from cleo.io.io import IO
@@ -21,7 +18,7 @@ class SelectChoiceValidator:
         self._question = question
         self._values = question.choices
 
-    def validate(self, selected: Union[str, int]) -> Optional[str]:
+    def validate(self, selected: str | int) -> str | None:
         """
         Validate a choice.
         """
@@ -89,7 +86,7 @@ class ChoiceQuestion(Question):
     """
 
     def __init__(
-        self, question: str, choices: List[str], default: Optional[Any] = None
+        self, question: str, choices: list[str], default: Any | None = None
     ) -> None:
         super().__init__(question, default)
 
@@ -105,7 +102,7 @@ class ChoiceQuestion(Question):
         return self._error_message
 
     @property
-    def choices(self) -> List[str]:
+    def choices(self) -> list[str]:
         return self._choices
 
     def supports_multiple_choices(self) -> bool:

--- a/cleo/ui/choice_question.py
+++ b/cleo/ui/choice_question.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from typing import Any

--- a/cleo/ui/component.py
+++ b/cleo/ui/component.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Component:
 
     name = None

--- a/cleo/ui/confirmation_question.py
+++ b/cleo/ui/confirmation_question.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from typing import Union

--- a/cleo/ui/confirmation_question.py
+++ b/cleo/ui/confirmation_question.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import re
 
-from typing import Union
-
 from cleo.io.io import IO
 
 from .question import Question
@@ -31,7 +29,7 @@ class ConfirmationQuestion(Question):
 
         io.write_error(message)
 
-    def _get_default_normalizer(self, answer: Union[str, bool]) -> bool:
+    def _get_default_normalizer(self, answer: str | bool) -> bool:
         """
         Default answer normalizer.
         """

--- a/cleo/ui/exception_trace.py
+++ b/cleo/ui/exception_trace.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import inspect
 import io

--- a/cleo/ui/exception_trace.py
+++ b/cleo/ui/exception_trace.py
@@ -9,10 +9,6 @@ import re
 import sys
 import tokenize
 
-from typing import List
-from typing import Optional
-from typing import Union
-
 from crashtest.frame import Frame
 from crashtest.frame_collection import FrameCollection
 from crashtest.inspector import Inspector
@@ -65,7 +61,7 @@ class Highlighter:
 
     def code_snippet(
         self, source: str, line: int, lines_before: int = 2, lines_after: int = 2
-    ) -> List[str]:
+    ) -> list[str]:
         token_lines = self.highlighted_lines(source)
         token_lines = self.line_numbers(token_lines, line)
 
@@ -76,12 +72,12 @@ class Highlighter:
 
         return token_lines
 
-    def highlighted_lines(self, source: str) -> List[str]:
+    def highlighted_lines(self, source: str) -> list[str]:
         source = source.replace("\r\n", "\n").replace("\r", "\n")
 
         return self.split_to_lines(source)
 
-    def split_to_lines(self, source: str) -> List[str]:
+    def split_to_lines(self, source: str) -> list[str]:
         lines = []
         current_line = 1
         current_col = 0
@@ -179,9 +175,7 @@ class Highlighter:
 
         return lines
 
-    def line_numbers(
-        self, lines: List[str], mark_line: Optional[int] = None
-    ) -> List[str]:
+    def line_numbers(self, lines: list[str], mark_line: int | None = None) -> list[str]:
         max_line_length = max(3, len(str(len(lines))))
 
         snippet_lines = []
@@ -239,19 +233,19 @@ class ExceptionTrace:
     def __init__(
         self,
         exception: Exception,
-        solution_provider_repository: Optional[SolutionProviderRepository] = None,
+        solution_provider_repository: SolutionProviderRepository | None = None,
     ) -> None:
         self._exception = exception
         self._solution_provider_repository = solution_provider_repository
         self._exc_info = sys.exc_info()
         self._ignore = None
 
-    def ignore_files_in(self, ignore: str) -> "ExceptionTrace":
+    def ignore_files_in(self, ignore: str) -> ExceptionTrace:
         self._ignore = ignore
 
         return self
 
-    def render(self, io: Union[IO, Output], simple: bool = False) -> None:
+    def render(self, io: IO | Output, simple: bool = False) -> None:
         if simple:
             io.write_line("")
             io.write_line(f"<error>{str(self._exception)}</error>")
@@ -259,7 +253,7 @@ class ExceptionTrace:
 
         return self._render_exception(io, self._exception)
 
-    def _render_exception(self, io: Union[IO, Output], exception: Exception) -> None:
+    def _render_exception(self, io: IO | Output, exception: Exception) -> None:
         from crashtest.inspector import Inspector
 
         inspector = Inspector(exception)
@@ -288,7 +282,7 @@ class ExceptionTrace:
 
         self._render_solution(io, inspector)
 
-    def _render_snippet(self, io: Union[IO, Output], frame: Frame) -> None:
+    def _render_snippet(self, io: IO | Output, frame: Frame) -> None:
         self._render_line(
             io,
             "at <fg=green>{}</>:<b>{}</b> in <fg=cyan>{}</>".format(
@@ -306,7 +300,7 @@ class ExceptionTrace:
         for code_line in code_lines:
             self._render_line(io, code_line, indent=4)
 
-    def _render_solution(self, io: Union[IO, Output], inspector: Inspector) -> None:
+    def _render_solution(self, io: IO | Output, inspector: Inspector) -> None:
         if self._solution_provider_repository is None:
             return
 
@@ -335,7 +329,7 @@ class ExceptionTrace:
                 True,
             )
 
-    def _render_trace(self, io: Union[IO, Output], frames: FrameCollection) -> None:
+    def _render_trace(self, io: IO | Output, frames: FrameCollection) -> None:
         stack_frames = FrameCollection()
         for frame in frames:
             if (
@@ -443,7 +437,7 @@ class ExceptionTrace:
                     i -= 1
 
     def _render_line(
-        self, io: Union[IO, Output], line: str, new_line: bool = False, indent: int = 2
+        self, io: IO | Output, line: str, new_line: bool = False, indent: int = 2
     ) -> None:
         if new_line:
             io.write_line("")

--- a/cleo/ui/progress_bar.py
+++ b/cleo/ui/progress_bar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import re
 import time

--- a/cleo/ui/progress_bar.py
+++ b/cleo/ui/progress_bar.py
@@ -5,8 +5,6 @@ import re
 import time
 
 from typing import Match
-from typing import Optional
-from typing import Union
 
 from cleo._utils import format_time
 from cleo.cursor import Cursor
@@ -45,7 +43,7 @@ class ProgressBar(Component):
 
     def __init__(
         self,
-        io: Union[IO, Output],
+        io: IO | Output,
         max: int = 0,
         min_seconds_between_redraws: float = 0.1,
     ) -> None:
@@ -104,7 +102,7 @@ class ProgressBar(Component):
     def get_progress_percent(self) -> float:
         return self._percent
 
-    def set_bar_character(self, character: str) -> "ProgressBar":
+    def set_bar_character(self, character: str) -> ProgressBar:
         self.bar_char = character
 
         return self
@@ -118,7 +116,7 @@ class ProgressBar(Component):
 
         return self.bar_char
 
-    def set_bar_width(self, width: int) -> "ProgressBar":
+    def set_bar_width(self, width: int) -> ProgressBar:
         self.bar_width = width
 
         return self
@@ -126,7 +124,7 @@ class ProgressBar(Component):
     def get_empty_bar_character(self) -> str:
         return self.empty_bar_char
 
-    def set_empty_bar_character(self, character: str) -> "ProgressBar":
+    def set_empty_bar_character(self, character: str) -> ProgressBar:
         self.empty_bar_char = character
 
         return self
@@ -134,7 +132,7 @@ class ProgressBar(Component):
     def get_progress_character(self) -> str:
         return self.progress_char
 
-    def set_progress_character(self, character: str) -> "ProgressBar":
+    def set_progress_character(self, character: str) -> ProgressBar:
         self.progress_char = character
 
         return self
@@ -143,7 +141,7 @@ class ProgressBar(Component):
         self._format = None
         self._internal_format = fmt
 
-    def set_redraw_frequency(self, freq: Optional[int]) -> None:
+    def set_redraw_frequency(self, freq: int | None) -> None:
         if self.redraw_freq is not None:
             self.redraw_freq = max(freq, 1)
 
@@ -155,7 +153,7 @@ class ProgressBar(Component):
     def max_seconds_between_redraws(self, freq: float) -> None:
         self._max_seconds_between_redraws = freq
 
-    def start(self, max: Optional[int] = None) -> None:
+    def start(self, max: int | None = None) -> None:
         """
         Start the progress output.
         """

--- a/cleo/ui/progress_indicator.py
+++ b/cleo/ui/progress_indicator.py
@@ -5,9 +5,6 @@ import threading
 import time
 
 from contextlib import contextmanager
-from typing import List
-from typing import Optional
-from typing import Union
 
 from cleo._utils import format_time
 from cleo.io.io import IO
@@ -28,10 +25,10 @@ class ProgressIndicator:
 
     def __init__(
         self,
-        io: Union[IO, Output],
-        fmt: Optional[str] = None,
+        io: IO | Output,
+        fmt: str | None = None,
         interval: int = 100,
-        values: Optional[List[str]] = None,
+        values: list[str] | None = None,
     ) -> None:
         if isinstance(io, IO):
             io = io.error_output
@@ -66,10 +63,10 @@ class ProgressIndicator:
         self._last_message_length = 0
 
     @property
-    def message(self) -> Optional[str]:
+    def message(self) -> str | None:
         return self._message
 
-    def set_message(self, message: Optional[str]) -> None:
+    def set_message(self, message: str | None) -> None:
         self._message = message
 
         self._display()

--- a/cleo/ui/progress_indicator.py
+++ b/cleo/ui/progress_indicator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import threading
 import time

--- a/cleo/ui/question.py
+++ b/cleo/ui/question.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import getpass
 import os
 import subprocess

--- a/cleo/ui/question.py
+++ b/cleo/ui/question.py
@@ -6,7 +6,6 @@ import subprocess
 
 from typing import Any
 from typing import Callable
-from typing import Optional
 
 from cleo.formatters.style import Style
 from cleo.io.io import IO
@@ -17,7 +16,7 @@ class Question:
     A question that will be asked in a Console.
     """
 
-    def __init__(self, question: str, default: Optional[Any] = None) -> None:
+    def __init__(self, question: str, default: Any | None = None) -> None:
         self._question = question
         self._default = default
 
@@ -42,7 +41,7 @@ class Question:
         return self._autocomplete_values
 
     @property
-    def max_attempts(self) -> Optional[int]:
+    def max_attempts(self) -> int | None:
         return self._attempts
 
     def is_hidden(self) -> bool:
@@ -66,7 +65,7 @@ class Question:
     def set_validator(self, validator: Callable) -> None:
         self._validator = validator
 
-    def ask(self, io: IO) -> Optional[str]:
+    def ask(self, io: IO) -> str | None:
         """
         Asks the question to the user.
         """
@@ -81,7 +80,7 @@ class Question:
 
         return self._validate_attempts(interviewer, io)
 
-    def _do_ask(self, io: IO) -> Optional[str]:
+    def _do_ask(self, io: IO) -> str | None:
         """
         Asks the question to the user.
         """

--- a/cleo/ui/table.py
+++ b/cleo/ui/table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import re
 

--- a/cleo/ui/table.py
+++ b/cleo/ui/table.py
@@ -4,10 +4,8 @@ import math
 import re
 
 from copy import deepcopy
-from typing import Dict
 from typing import Generator
 from typing import List
-from typing import Optional
 from typing import Union
 
 from cleo.formatters.formatter import Formatter
@@ -34,9 +32,9 @@ class Table:
     BORDER_OUTSIDE: int = 0
     BORDER_INSIDE: int = 1
 
-    _styles: Optional[Dict[str, TableStyle]] = None
+    _styles: dict[str, TableStyle] | None = None
 
-    def __init__(self, io: Union[IO, Output], style: str = None) -> None:
+    def __init__(self, io: IO | Output, style: str = None) -> None:
         self._io = io
 
         if style is None:
@@ -50,17 +48,17 @@ class Table:
         self._rows = []
         self._horizontal = False
 
-        self._effective_column_widths: Dict[int, int] = {}
+        self._effective_column_widths: dict[int, int] = {}
 
         self._number_of_columns = None
 
-        self._column_styles: Dict[int, TableStyle] = {}
-        self._column_widths: Dict[int, int] = {}
-        self._column_max_widths: Dict[int, int] = {}
+        self._column_styles: dict[int, TableStyle] = {}
+        self._column_widths: dict[int, int] = {}
+        self._column_max_widths: dict[int, int] = {}
 
         self._rendered = False
 
-        self._style: Optional[TableStyle] = None
+        self._style: TableStyle | None = None
         self._init_styles()
         self.set_style(style)
 
@@ -68,7 +66,7 @@ class Table:
     def style(self) -> TableStyle:
         return self._style
 
-    def set_style(self, name: str) -> "Table":
+    def set_style(self, name: str) -> Table:
         self._init_styles()
 
         self._style = self._resolve_style(name)
@@ -81,19 +79,17 @@ class Table:
 
         return self._style
 
-    def set_column_style(
-        self, column_index: int, style: Union[str, TableStyle]
-    ) -> "Table":
+    def set_column_style(self, column_index: int, style: str | TableStyle) -> Table:
         self._column_styles[column_index] = self._resolve_style(style)
 
         return self
 
-    def set_column_width(self, column_index: int, width: int) -> "Table":
+    def set_column_width(self, column_index: int, width: int) -> Table:
         self._column_widths[column_index] = width
 
         return self
 
-    def set_column_widths(self, widths: List[int]) -> "Table":
+    def set_column_widths(self, widths: list[int]) -> Table:
         self._column_widths = {}
 
         for i, width in enumerate(widths):
@@ -101,12 +97,12 @@ class Table:
 
         return self
 
-    def set_column_max_width(self, column_index: int, width: int) -> "Table":
+    def set_column_max_width(self, column_index: int, width: int) -> Table:
         self._column_widths[column_index] = width
 
         return self
 
-    def set_headers(self, headers: List[str]) -> "Table":
+    def set_headers(self, headers: list[str]) -> Table:
         if headers and not isinstance(headers[0], list):
             headers = [headers]
 
@@ -114,18 +110,18 @@ class Table:
 
         return self
 
-    def set_rows(self, rows: _Rows) -> "Table":
+    def set_rows(self, rows: _Rows) -> Table:
         self._rows = []
 
         return self.add_rows(rows)
 
-    def add_rows(self, rows: _Rows) -> "Table":
+    def add_rows(self, rows: _Rows) -> Table:
         for row in rows:
             self.add_row(row)
 
         return self
 
-    def add_row(self, row: Union[_Row, TableSeparator]) -> "Table":
+    def add_row(self, row: _Row | TableSeparator) -> Table:
         if isinstance(row, TableSeparator):
             self._rows.append(row)
 
@@ -135,17 +131,17 @@ class Table:
 
         return self
 
-    def set_header_title(self, header_title: str) -> "Table":
+    def set_header_title(self, header_title: str) -> Table:
         self._header_title = header_title
 
         return self
 
-    def set_footer_title(self, footer_title: str) -> "Table":
+    def set_footer_title(self, footer_title: str) -> Table:
         self._footer_title = footer_title
 
         return self
 
-    def horizontal(self, horizontal: bool = True) -> "Table":
+    def horizontal(self, horizontal: bool = True) -> Table:
         self._horizontal = horizontal
 
         return self
@@ -229,8 +225,8 @@ class Table:
     def _render_row_separator(
         self,
         type: int = SEPARATOR_MID,
-        title: Optional[str] = None,
-        title_format: Optional[str] = None,
+        title: str | None = None,
+        title_format: str | None = None,
     ) -> None:
         """
         Renders horizontal header separator.
@@ -315,7 +311,7 @@ class Table:
         )
 
     def _render_row(
-        self, row: List[str], cell_format: str, first_cell_format: Optional[str] = None
+        self, row: list[str], cell_format: str, first_cell_format: str | None = None
     ) -> None:
         """
         Renders table row.
@@ -542,7 +538,7 @@ class Table:
 
         return rows
 
-    def _fill_cells(self, row: _Row) -> List[Union[str, TableCell]]:
+    def _fill_cells(self, row: _Row) -> list[str | TableCell]:
         """
         Fills cells for a row that contains colspan > 1.
         """
@@ -585,7 +581,7 @@ class Table:
 
         return columns
 
-    def _get_row_columns(self, row: _Row) -> List[int]:
+    def _get_row_columns(self, row: _Row) -> list[int]:
         """
         Gets list of columns for the given row.
         """
@@ -702,7 +698,7 @@ class Table:
         }
 
     @classmethod
-    def _resolve_style(cls, name: Union[str, TableStyle]) -> TableStyle:
+    def _resolve_style(cls, name: str | TableStyle) -> TableStyle:
         if isinstance(name, TableStyle):
             return name
 

--- a/cleo/ui/table_cell.py
+++ b/cleo/ui/table_cell.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from .table_cell_style import TableCellStyle
 
 
@@ -11,8 +9,8 @@ class TableCell(str):
         value: str = "",
         rowspan: int = 1,
         colspan: int = 1,
-        style: Optional[TableCellStyle] = None,
-    ) -> "TableCell":
+        style: TableCellStyle | None = None,
+    ) -> TableCell:
         return super().__new__(cls, value)
 
     def __init__(
@@ -20,7 +18,7 @@ class TableCell(str):
         value: str = "",
         rowspan: int = 1,
         colspan: int = 1,
-        style: Optional[TableCellStyle] = None,
+        style: TableCellStyle | None = None,
     ) -> None:
         self._rowspan = rowspan
         self._colspan = colspan
@@ -35,5 +33,5 @@ class TableCell(str):
         return self._colspan
 
     @property
-    def style(self) -> Optional[TableCellStyle]:
+    def style(self) -> TableCellStyle | None:
         return self._style

--- a/cleo/ui/table_cell.py
+++ b/cleo/ui/table_cell.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from .table_cell_style import TableCellStyle

--- a/cleo/ui/table_cell_style.py
+++ b/cleo/ui/table_cell_style.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 
 class TableCellStyle:
     def __init__(
@@ -14,7 +12,7 @@ class TableCellStyle:
         self._cell_format = cell_format
 
     @property
-    def cell_format(self) -> Optional[str]:
+    def cell_format(self) -> str | None:
         return self._cell_format
 
     @property

--- a/cleo/ui/table_cell_style.py
+++ b/cleo/ui/table_cell_style.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 

--- a/cleo/ui/table_separator.py
+++ b/cleo/ui/table_separator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .table_cell import TableCell
 
 

--- a/cleo/ui/table_style.py
+++ b/cleo/ui/table_style.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-from typing import Optional
-
 
 class TableStyle:
     """
@@ -40,7 +37,7 @@ class TableStyle:
         return self._padding_char
 
     @property
-    def border_chars(self) -> List[str]:
+    def border_chars(self) -> list[str]:
         return [
             self._horizontal_outside_border_char,
             self._vertical_outside_border_char,
@@ -53,7 +50,7 @@ class TableStyle:
         return self._crossing_char
 
     @property
-    def crossing_chars(self) -> List[str]:
+    def crossing_chars(self) -> list[str]:
         return [
             self._crossing_char,
             self._crossing_top_left_char,
@@ -97,7 +94,7 @@ class TableStyle:
     def pad_type(self) -> str:
         return self._pad_type
 
-    def set_padding_char(self, padding_char: str) -> "TableStyle":
+    def set_padding_char(self, padding_char: str) -> TableStyle:
         """
         Sets padding character, used for cell padding.
         """
@@ -109,8 +106,8 @@ class TableStyle:
         return self
 
     def set_horizontal_border_chars(
-        self, outside: str, inside: Optional[str] = None
-    ) -> "TableStyle":
+        self, outside: str, inside: str | None = None
+    ) -> TableStyle:
         """
         Sets horizontal border characters.
 
@@ -129,8 +126,8 @@ class TableStyle:
         return self
 
     def set_vertical_border_chars(
-        self, outside: str, inside: Optional[str] = None
-    ) -> "TableStyle":
+        self, outside: str, inside: str | None = None
+    ) -> TableStyle:
         """
         Sets vertical border characters.
 
@@ -160,10 +157,10 @@ class TableStyle:
         bottom_mid: str,
         bottom_left: str,
         mid_left: str,
-        top_left_bottom: Optional[str] = None,
-        top_mid_bottom: Optional[str] = None,
-        top_right_bottom: Optional[str] = None,
-    ) -> "TableStyle":
+        top_left_bottom: str | None = None,
+        top_mid_bottom: str | None = None,
+        top_right_bottom: str | None = None,
+    ) -> TableStyle:
         """
         Sets crossing characters.
 
@@ -200,7 +197,7 @@ class TableStyle:
 
         return self
 
-    def set_default_crossing_char(self, char: str) -> "TableStyle":
+    def set_default_crossing_char(self, char: str) -> TableStyle:
         """
         Sets default crossing character used for each cross.
         """
@@ -208,7 +205,7 @@ class TableStyle:
             char, char, char, char, char, char, char, char, char
         )
 
-    def set_cell_header_format(self, cell_header_format: str) -> "TableStyle":
+    def set_cell_header_format(self, cell_header_format: str) -> TableStyle:
         """
         Sets the header cell format.
         """
@@ -216,7 +213,7 @@ class TableStyle:
 
         return self
 
-    def set_cell_row_format(self, cell_row_format: str) -> "TableStyle":
+    def set_cell_row_format(self, cell_row_format: str) -> TableStyle:
         """
         Sets the row cell format.
         """
@@ -224,7 +221,7 @@ class TableStyle:
 
         return self
 
-    def set_cell_row_content_format(self, cell_row_content_format: str) -> "TableStyle":
+    def set_cell_row_content_format(self, cell_row_content_format: str) -> TableStyle:
         """
         Sets the row cell content format.
         """
@@ -232,7 +229,7 @@ class TableStyle:
 
         return self
 
-    def set_border_format(self, border_format: str) -> "TableStyle":
+    def set_border_format(self, border_format: str) -> TableStyle:
         """
         Sets the border format.
         """
@@ -240,7 +237,7 @@ class TableStyle:
 
         return self
 
-    def set_header_title_format(self, header_title_format: str) -> "TableStyle":
+    def set_header_title_format(self, header_title_format: str) -> TableStyle:
         """
         Sets the header title format.
         """
@@ -248,7 +245,7 @@ class TableStyle:
 
         return self
 
-    def set_footer_title_format(self, footer_title_format: str) -> "TableStyle":
+    def set_footer_title_format(self, footer_title_format: str) -> TableStyle:
         """
         Sets the footer title format.
         """
@@ -256,7 +253,7 @@ class TableStyle:
 
         return self
 
-    def set_pad_type(self, pad_type: str) -> "TableStyle":
+    def set_pad_type(self, pad_type: str) -> TableStyle:
         """
         Sets the padding type.
         """

--- a/cleo/ui/table_style.py
+++ b/cleo/ui/table_style.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Optional
 

--- a/cleo/ui/ui.py
+++ b/cleo/ui/ui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 from typing import List
 from typing import Optional

--- a/cleo/ui/ui.py
+++ b/cleo/ui/ui.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from typing import Dict
-from typing import List
-from typing import Optional
-
 from cleo.exceptions import ValueException
 
 from .component import Component
 
 
 class UI:
-    def __init__(self, components: Optional[List[Component]] = None) -> None:
-        self._components: Dict[str, Component] = {}
+    def __init__(self, components: list[Component] | None = None) -> None:
+        self._components: dict[str, Component] = {}
 
         if components is None:
             components = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import annotations
+
 import os
 
 

--- a/tests/commands/completion/fixtures/command_with_colons.py
+++ b/tests/commands/completion/fixtures/command_with_colons.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/commands/completion/fixtures/hello_command.py
+++ b/tests/commands/completion/fixtures/hello_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/commands/completion/test_completions_command.py
+++ b/tests/commands/completion/test_completions_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pytest

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.application import Application
 from cleo.commands.command import Command
 from cleo.helpers import argument

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/tests/events/test_event.py
+++ b/tests/events/test_event.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.events.event import Event
 
 

--- a/tests/events/test_event_dispatcher.py
+++ b/tests/events/test_event_dispatcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.events.event import Event

--- a/tests/fixtures/foo1_command.py
+++ b/tests/fixtures/foo1_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/fixtures/foo2_command.py
+++ b/tests/fixtures/foo2_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/fixtures/foo_command.py
+++ b/tests/fixtures/foo_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 from cleo.io.io import IO
 

--- a/tests/fixtures/foo_sub_namespaced1_command.py
+++ b/tests/fixtures/foo_sub_namespaced1_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/fixtures/foo_sub_namespaced2_command.py
+++ b/tests/fixtures/foo_sub_namespaced2_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/fixtures/inherited_command.py
+++ b/tests/fixtures/inherited_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/fixtures/signature_command.py
+++ b/tests/fixtures/signature_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.commands.command import Command
 
 

--- a/tests/formatters/test_formatter.py
+++ b/tests/formatters/test_formatter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.formatters.formatter import Formatter

--- a/tests/io/inputs/test_argument.py
+++ b/tests/io/inputs/test_argument.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.exceptions import LogicException

--- a/tests/io/inputs/test_argv_input.py
+++ b/tests/io/inputs/test_argv_input.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/io/inputs/test_option.py
+++ b/tests/io/inputs/test_option.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.exceptions import LogicException

--- a/tests/io/inputs/test_token_parser.py
+++ b/tests/io/inputs/test_token_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.io.inputs.token_parser import TokenParser

--- a/tests/io/outputs/test_section_output.py
+++ b/tests/io/outputs/test_section_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import StringIO
 
 import pytest

--- a/tests/loaders/test_factory_command_loader.py
+++ b/tests/loaders/test_factory_command_loader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.commands.command import Command

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 from pathlib import Path
-from typing import Dict
 
 import pytest
 
@@ -201,7 +200,7 @@ def test_find_ambiguous_command_hidden(app: Application):
         app.find("foo b")
 
 
-def test_set_catch_exceptions(app: Application, environ: Dict[str, str]):
+def test_set_catch_exceptions(app: Application, environ: dict[str, str]):
     app.auto_exits(False)
     os.environ["COLUMNS"] = "120"
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pytest

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.helpers import argument
 from cleo.helpers import option
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.parser import Parser
 
 

--- a/tests/testers/test_application_tester.py
+++ b/tests/testers/test_application_tester.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.application import Application

--- a/tests/testers/test_command_tester.py
+++ b/tests/testers/test_command_tester.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.application import Application

--- a/tests/ui/test_choice_question.py
+++ b/tests/ui/test_choice_question.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.exceptions import ValueException

--- a/tests/ui/test_confirmation_question.py
+++ b/tests/ui/test_confirmation_question.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from cleo.ui.confirmation_question import ConfirmationQuestion
 
 

--- a/tests/ui/test_progress_bar.py
+++ b/tests/ui/test_progress_bar.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import time
 
-from typing import List
-
 import pytest
 
 from cleo.io.outputs.output import Verbosity
@@ -20,7 +18,7 @@ def ansi_bar(ansi_io):
     return ProgressBar(ansi_io, min_seconds_between_redraws=0)
 
 
-def generate_output(expected: List[str]) -> str:
+def generate_output(expected: list[str]) -> str:
     output = ""
     for i, line in enumerate(expected):
         if i:

--- a/tests/ui/test_progress_bar.py
+++ b/tests/ui/test_progress_bar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from typing import List

--- a/tests/ui/test_progress_indicator.py
+++ b/tests/ui/test_progress_indicator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from cleo.ui.progress_indicator import ProgressIndicator

--- a/tests/ui/test_question.py
+++ b/tests/ui/test_question.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 

--- a/tests/ui/test_table.py
+++ b/tests/ui/test_table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from cleo.ui.table import Table


### PR DESCRIPTION
This updates our type annotations to take advantage of [PEP 563](https://www.python.org/dev/peps/pep-0563/) and [PEP 585](https://www.python.org/dev/peps/pep-0585/).
All the heavy lifting was done by `pyupgrade`.

Relates to https://github.com/python-poetry/poetry/pull/5088
