### PR TITLE
Docs: Update Autocompletion section

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,16 +446,7 @@ the `call_silent()` method instead.
 
 Cleo supports automatic (tab) completion in `bash`, `zsh` and `fish`.
 
-To activate support for autocompletion, pass a `complete` keyword when
-initializing your application:
-
-```python
-application = Application("My Application", "0.1", complete=True)
-```
-
-Now, register completion for your application by running one of the
-following in a terminal, replacing `[program]` with the command you use
-to run your application:
+By default, your application will have a `completions` command. To register these completions for your application, run one of the following in a terminal (replacing `[program]` with the command you use to run your application):
 
 ```bash
 # Bash

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -500,21 +500,32 @@ Autocompletion
 
 Cleo supports automatic (tab) completion in ``bash``, ``zsh`` and ``fish``.
 
-You can register completion for your application by running one of the following in a terminal,
-replacing ``[program]`` with the command you use to run your application:
+To activate support for autocompletion, pass a ``complete`` keyword when
+initializing your application:
+
+.. code-block:: python
+
+    application = Application("My Application", "0.1", complete=True)
+
+Now, register completion for your application by running one of the
+following in a terminal, replacing ``[program]`` with the command you use
+to run your application:
 
 .. code-block:: bash
 
-    # BASH - Ubuntu / Debian
+    # Bash
     [program] completions bash | sudo tee /etc/bash_completion.d/[program].bash-completion
 
-    # BASH - Mac OSX (with Homebrew "bash-completion")
+    # Bash - macOS/Homebrew (requires `brew install bash-completion`)
     [program] completions bash > $(brew --prefix)/etc/bash_completion.d/[program].bash-completion
 
-    # ZSH - Config file
+    # Zsh
     mkdir ~/.zfunc
     echo "fpath+=~/.zfunc" >> ~/.zshrc
-    [program] completions zsh > ~/.zfunc/_test
+    [program] completions zsh > ~/.zfunc/_[program]
 
-    # FISH
+    # Zsh - macOS/Homebrew
+    [program] completions zsh > $(brew --prefix)/share/zsh/site-functions/_[program]
+
+    # Fish
     [program] completions fish > ~/.config/fish/completions/[program].fish

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -500,16 +500,7 @@ Autocompletion
 
 Cleo supports automatic (tab) completion in ``bash``, ``zsh`` and ``fish``.
 
-To activate support for autocompletion, pass a ``complete`` keyword when
-initializing your application:
-
-.. code-block:: python
-
-    application = Application("My Application", "0.1", complete=True)
-
-Now, register completion for your application by running one of the
-following in a terminal, replacing ``[program]`` with the command you use
-to run your application:
+By default, your application will have a ``completions`` command. To register these completions for your application, run one of the following in a terminal (replacing ``[program]`` with the command you use to run your application):
 
 .. code-block:: bash
 


### PR DESCRIPTION
Aligning this section in the doc site to match with the root README. This is a follow-up for https://github.com/python-poetry/cleo/pull/77 where the README was updated.