### PR TITLE
refactor: move exception fixtures out tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: isort
         args: [--add-import, from __future__ import annotations]
-        exclude: ^tests/ui/(helpers|test_exception_trace).py$
+        exclude: ^tests/fixtures/exceptions/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.910

--- a/tests/fixtures/exceptions/nested1.py
+++ b/tests/fixtures/exceptions/nested1.py
@@ -1,0 +1,5 @@
+def outer() -> None:
+    def inner() -> None:
+        raise Exception("Foo")
+
+    inner()

--- a/tests/fixtures/exceptions/nested2.py
+++ b/tests/fixtures/exceptions/nested2.py
@@ -1,0 +1,8 @@
+from tests.fixtures.exceptions.nested1 import outer
+
+
+def call() -> None:
+    def run() -> None:
+        outer()
+
+    run()

--- a/tests/fixtures/exceptions/recursion.py
+++ b/tests/fixtures/exceptions/recursion.py
@@ -1,0 +1,2 @@
+def recursion_error() -> None:
+    recursion_error()

--- a/tests/fixtures/exceptions/simple.py
+++ b/tests/fixtures/exceptions/simple.py
@@ -1,0 +1,2 @@
+def simple_exception() -> None:
+    raise Exception("Failed")

--- a/tests/fixtures/exceptions/solution.py
+++ b/tests/fixtures/exceptions/solution.py
@@ -1,0 +1,16 @@
+from crashtest.contracts.base_solution import BaseSolution
+from crashtest.contracts.provides_solution import ProvidesSolution
+
+
+class CustomError(ProvidesSolution, Exception):
+    @property
+    def solution(self) -> BaseSolution:
+        solution = BaseSolution("Solution Title.", "Solution Description")
+        solution.documentation_links.append("https://example.com")
+        solution.documentation_links.append("https://example2.com")
+
+        return solution
+
+
+def call() -> None:
+    raise CustomError("Error with solution")

--- a/tests/ui/helpers.py
+++ b/tests/ui/helpers.py
@@ -1,5 +1,0 @@
-def outer():
-    def inner():
-        raise Exception("Foo")
-
-    inner()


### PR DESCRIPTION
Currently, `test_exception_trace.py` tests exact line numbers in stack traces of code within its own file. This makes it hard for refactoring, so instead factor as much out into separate fixture files.
