### PR TITLE
Fix zsh completion

### DIFF
--- a/cleo/commands/completions/templates.py
+++ b/cleo/commands/completions/templates.py
@@ -55,7 +55,9 @@ ZSH_TEMPLATE = """#compdef %(script_name)s
 
 %(function)s()
 {
-    local com coms cur opts state
+    local state com cur
+    local -a opts
+    local -a coms
 
     cur=${words[${#words[@]}]}
 
@@ -69,10 +71,10 @@ ZSH_TEMPLATE = """#compdef %(script_name)s
 
     if [[ ${cur} == --* ]]; then
         state="option"
-        opts=(%(opts)s)
+        opts+=(%(opts)s)
     elif [[ $cur == $com ]]; then
         state="command"
-        coms=(%(coms)s)
+        coms+=(%(coms)s)
     fi
 
     case $state in

--- a/tests/commands/completion/fixtures/zsh.txt
+++ b/tests/commands/completion/fixtures/zsh.txt
@@ -2,7 +2,9 @@
 
 _my_function()
 {
-    local com coms cur opts state
+    local state com cur
+    local -a opts
+    local -a coms
 
     cur=${words[${#words[@]}]}
 
@@ -16,10 +18,10 @@ _my_function()
 
     if [[ ${cur} == --* ]]; then
         state="option"
-        opts=("--ansi:Force ANSI output." "--help:Display help for the given command. When no command is given display help for the list command." "--no-ansi:Disable ANSI output." "--no-interaction:Do not ask any interactive question." "--quiet:Do not output any message." "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug." "--version:Display this application version.")
+        opts+=("--ansi:Force ANSI output." "--help:Display help for the given command. When no command is given display help for the list command." "--no-ansi:Disable ANSI output." "--no-interaction:Do not ask any interactive question." "--quiet:Do not output any message." "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug." "--version:Display this application version.")
     elif [[ $cur == $com ]]; then
         state="command"
-        coms=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands.")
+        coms+=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands.")
     fi
 
     case $state in


### PR DESCRIPTION
Before we were implicitly declaring the `opts` and `coms` arrays, which had the undesired effect of zsh parsing it as an associative array instead of a normal array. 

Now we explicitly declare the `opts` and `coms` arrays to be normal arrays.