### PR TITLE
don't flush() on every write()

### DIFF
--- a/cleo/io/outputs/stream_output.py
+++ b/cleo/io/outputs/stream_output.py
@@ -82,7 +82,6 @@ class StreamOutput(Output):
             message += "\n"
 
         self._stream.write(message)
-        self._stream.flush()
 
     def _has_color_support(self) -> bool:
         # Follow https://no-color.org/


### PR DESCRIPTION
Fixes https://github.com/python-poetry/poetry/issues/3602

Not clear to me what the intention of all that flushing was, I haven't seen any obvious downside to getting rid of it altogether.