### PR TITLE
fix readme, should specify command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ from cleo.commands.command import Command
 
 
 class GreetCommand(Command):
+
+    # specify command name *require
+    name = "great"
+
     """
     Greets someone
 


### PR DESCRIPTION
In README not specify, that I should add command name in my command and I got this error.

```
File "/usr/local/lib/python3.7/dist-packages/clikit/console_application.py", line 161, in add_command
    self._validate_command_name(config.name)
  File "/usr/local/lib/python3.7/dist-packages/clikit/console_application.py", line 174, in _validate_command_name
    raise CannotAddCommandException.name_empty()
clikit.api.command.exceptions.CannotAddCommandException: The command name must be set.
```
