### PR TITLE
Change default command to `help` from `list`

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -62,7 +62,7 @@ class Application:
         self._version = version
         self._display_name: str | None = None
         self._terminal = shutil.get_terminal_size()
-        self._default_command = "list"
+        self._default_command = "help"
         self._single_command = False
         self._commands: dict[str, Command] = {}
         self._running_command = None


### PR DESCRIPTION
PR related to these issues:

https://github.com/python-poetry/cleo/issues/182

https://github.com/python-poetry/cleo/issues/249

Changes the default command from `list` to `help`.