### PR TITLE
ci: fix cache on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
+        if: steps.cache.outputs.cache-hit == 'true' && matrix.os != 'MacOS'
         run: timeout 10s poetry run pip --version || rm -rf .venv
 
       - name: Install dependencies


### PR DESCRIPTION
Since macOS doesn't come with a `timeout` command, our venv health check fails and removes our venv each time (for example, see [the logs](https://github.com/python-poetry/cleo/runs/7549937631?check_suite_focus=true#step:10:7)). I've skipped the healthcheck here since I'm not sure how often it's really needed, but if we find it is we should find a cross-platform solution.
