### PR TITLE
Fix document of text coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,16 @@ Whenever you output text, you can surround the text with tags to color
 its output. For example:
 
 ```python
-# green text
+# blue text
 self.line("<info>foo</info>")
 
-# yellow text
+# green text
 self.line("<comment>foo</comment>")
 
-# black text on a cyan background
+# cyan text
 self.line("<question>foo</question>")
 
-# white text on a red background
+# bold red text
 self.line("<error>foo</error>")
 ```
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -110,17 +110,17 @@ output. For example:
 
 .. code-block:: python
 
+    # blue text
+    self.line("<info>foo</info>")
+
     # green text
-    self.line('<info>foo</info>')
+    self.line("<comment>foo</comment>")
 
-    # yellow text
-    self.line('<comment>foo</comment>')
+    # cyan text
+    self.line("<question>foo</question>")
 
-    # black text on a cyan background
-    self.line('<question>foo</question>')
-
-    # white text on a red background
-    self.line('<error>foo</error>')
+    # bold red text
+    self.line("<error>foo</error>")
 
 The closing tag can be replaced by ``</>``, which revokes all formatting options established by the last opened tag.
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -122,6 +122,15 @@ output. For example:
     # bold red text
     self.line("<error>foo</error>")
 
+    # cyan text
+    self.line("<c1>foo</c1>")
+
+    # bold text
+    self.line("<c2>foo</c2>")
+
+    # bold text
+    self.line("<b>foo</b>")
+
 The closing tag can be replaced by ``</>``, which revokes all formatting options established by the last opened tag.
 
 It is possible to define your own styles using the ``add_style()`` method:


### PR DESCRIPTION
Found the style got changed in [formatter](https://github.com/python-poetry/cleo/blob/db6f7957a00383df097386a23309f4787ef3faff/cleo/formatters/formatter.py#L22-L28) but the document isn't updated.

Feeling a bit misleading so fix it.
