### PR TITLE
fix: don't clear `interactive` state on namespace commands

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -417,8 +417,10 @@ class Application:
                 del argv[index + 1 : index + 1 + (len(name.split(" ")) - 1)]
 
             stream = io.input.stream
+            interactive = io.input.is_interactive()
             io.set_input(ArgvInput(argv))
             io.input.set_stream(stream)
+            io.input.interactive(interactive)
 
         exit_code = self._run_command(command, io)
         self._running_command = None

--- a/tests/fixtures/foo3_command.py
+++ b/tests/fixtures/foo3_command.py
@@ -12,6 +12,6 @@ class Foo3Command(Command):
     aliases = ["foo3"]
 
     def handle(self) -> int:
-        question = self.ask("echo:")
+        question = self.ask("echo:", default="default input")
         self.line(question)
         return 0

--- a/tests/fixtures/foo_sub_namespaced3_command.py
+++ b/tests/fixtures/foo_sub_namespaced3_command.py
@@ -12,6 +12,6 @@ class FooSubNamespaced3Command(Command):
     aliases = ["foobar"]
 
     def handle(self) -> int:
-        question = self.ask("")
+        question = self.ask("", default="default input")
         self.line(question)
         return 0

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -376,3 +376,15 @@ def test_run_namespaced_with_input() -> None:
 
     assert status_code == 0
     assert tester.io.fetch_output() == "Hello world!\n"
+
+
+@pytest.mark.parametrize("cmd", (Foo3Command(), FooSubNamespaced3Command()))
+def test_run_with_input_and_non_interactive(cmd: Command) -> None:
+    app = Application()
+    app.add(cmd)
+
+    tester = ApplicationTester(app)
+    status_code = tester.execute(f"--no-interaction {cmd.name}", inputs="Hello world!")
+
+    assert status_code == 0
+    assert tester.io.fetch_output() == "default input\n"


### PR DESCRIPTION
When running a namespaced command like `cache clear`, we reset the input (seemingly to parse the command as a single string) but also unintentionally reset `io.input._interactive`.

Similar bug as #135
Relates to https://github.com/python-poetry/poetry/pull/6212
