### PR TITLE
fix: `Output.supports_utf8` must be a function

### DIFF
--- a/cleo/io/outputs/stream_output.py
+++ b/cleo/io/outputs/stream_output.py
@@ -42,7 +42,6 @@ class StreamOutput(Output):
     def stream(self) -> TextIO:
         return self._stream
 
-    @property
     def supports_utf8(self) -> bool:
         return self._supports_utf8
 


### PR DESCRIPTION
Follow up to #228, `supports_utf8` must be a function (not sure why mypy didn't catch this):

https://github.com/python-poetry/cleo/blob/1f7e94a55881e03c3d9ebf563134885c468f0988/cleo/io/outputs/output.py#L61-L65
