### PR TITLE
fix: gracefully handle SIGPIPE

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -325,6 +325,12 @@ class Application:
 
             try:
                 exit_code = self._run(io)
+            except BrokenPipeError:
+                # If we are piped to another process, it may close early and send a
+                # SIGPIPE: https://docs.python.org/3/library/signal.html#note-on-sigpipe
+                devnull = os.open(os.devnull, os.O_WRONLY)
+                os.dup2(devnull, sys.stdout.fileno())
+                exit_code = 0
             except Exception as e:
                 if not self._catch_exceptions:
                     raise

--- a/cleo/io/outputs/stream_output.py
+++ b/cleo/io/outputs/stream_output.py
@@ -77,6 +77,7 @@ class StreamOutput(Output):
             message += "\n"
 
         self._stream.write(message)
+        self._stream.flush()
 
     def _has_color_support(self) -> bool:
         # Follow https://no-color.org/


### PR DESCRIPTION
When fixing #234, I noticed cleo's terminal prompt wasn't rendering until after reading a response:

```console
$ poetry cache clear --all .
no # cleo is prompting here
Delete 575 entries? (yes/no) [no] # but output is displayed later
```

This was introduced via #165, since now we aren't always flushing the output. This reverts that and instead suppresses a broken pipe error, which was the initial motivation for that PR.
Note that `click` also [always flushes output](https://github.com/pallets/click/blob/08f71b08e2b7ee9b1ea27daf6d3040999fc68551/src/click/utils.py#L225) and similary [ignores broken pipes](https://github.com/pallets/click/blob/08f71b08e2b7ee9b1ea27daf6d3040999fc68551/src/click/utils.py#L452).

I manually tested this with `poetry -V | head -1`

Closes #56
