### PR TITLE
chore(config): cleanup configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,49 +2,6 @@ ci:
   autofix_prs: false
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.6.0
-    hooks:
-      - id: black
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-      - id: yesqa
-        additional_dependencies: &flake8_deps
-          - flake8-broken-line==0.5.0
-          - flake8-bugbear==22.7.1
-          - flake8-comprehensions==3.10.0
-          - flake8-eradicate==1.3.0
-          - flake8-quotes==3.3.1
-          - flake8-simplify==0.19.2
-          - flake8-tidy-imports==4.8.0
-          - flake8-type-checking==2.1.2
-          - flake8-typing-imports==1.12.0
-          - flake8-use-fstring==1.3
-          - pep8-naming==0.13.0
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        args: [--add-import, from __future__ import annotations]
-        exclude: ^tests/fixtures/exceptions/
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
-    hooks:
-      - id: mypy
-        pass_filenames: false
-        additional_dependencies:
-          - pytest>=7.1.2
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        additional_dependencies: *flake8_deps
-
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.37.3
     hooks:
@@ -56,4 +13,45 @@ repos:
     rev: v2.1.1
     hooks:
       - id: pycln
-        args: [--all]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        exclude: ^tests/fixtures/exceptions/
+
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
+    hooks:
+      - id: yesqa
+        additional_dependencies: &flake8_deps
+          - flake8-broken-line==0.5.0
+          - flake8-bugbear==22.8.23
+          - flake8-comprehensions==3.10.0
+          - flake8-eradicate==1.3.0
+          - flake8-quotes==3.3.1
+          - flake8-simplify==0.19.3
+          - flake8-tidy-imports==4.8.0
+          - flake8-type-checking==2.1.2
+          - flake8-typing-imports==1.13.0
+          - flake8-use-fstring==1.4
+          - pep8-naming==0.13.2
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+        additional_dependencies: *flake8_deps
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.971
+    hooks:
+      - id: mypy
+        pass_filenames: false
+        additional_dependencies:
+          - pytest>=7.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,15 +45,24 @@ force_single_line = true
 atomic = true
 lines_after_imports = 2
 lines_between_types = 1
-src_paths = ["cleo", "tests"]
-skip_glob = ["*/setup.py"]
+src_paths = [
+    "cleo",
+    "tests"
+]
+add_imports = [
+    "from __future__ import annotations"
+]
 filter_files = true
 known_first_party = "cleo"
+
+[tool.pycln]
+all = true
 
 [tool.mypy]
 strict = true
 files = "cleo, tests"
 show_error_codes = true
+pretty = true
 
 # The following whitelist is used to allow for incremental adoption
 # of Mypy. Modules should be removed from this whitelist as and when


### PR DESCRIPTION
## Changes

- moved all possible configs from `.pre-commit-config.yaml` to `pyproject.toml`
- revied all config options 
- updated `additional_dependencies` for `yesqa` and `flake8` pre-commit hooks
- reordered pre-commit hooks for in a way it makes more sense (like removing imports before formatting or linter checks)