### PR TITLE
Fix sphinx warnings.

### DIFF
--- a/docs/helpers/formatter_helper.rst
+++ b/docs/helpers/formatter_helper.rst
@@ -1,0 +1,64 @@
+Formatter Helper
+################
+
+The Formatter helper provides functions to format the output with colors.
+You can do more advanced things with this helper than you can in
+:ref:`output-coloring`.
+
+The ``FormatterHelper`` class is included
+in the default helper set, which you can get by calling
+``Command.get_helper()``:
+
+.. code-block:: python
+
+    formatter = self.get_helper('formatter')
+
+The methods return a string, which you'll usually render to the console by
+passing it to the ``line()`` method.
+
+Print Messages in a Section
+===========================
+
+Cleo offers a defined style when printing a message that belongs to some
+"section". It prints the section in color and with brackets around it and the
+actual message to the right of this. Minus the color, it looks like this:
+
+.. code-block:: text
+
+    [SomeSection] Here is some message related to that section
+
+To reproduce this style, you can use the
+``format_section()`` method:
+
+.. code-block:: python
+
+    formatted_line = formatter.format_section(
+        'SomeSection',
+        'Here is some message related to that section'
+    )
+    self.line(formatted_line)
+
+Print Messages in a Block
+=========================
+
+Sometimes you want to be able to print a whole block of text with a background
+color. Cleo uses this when printing error messages.
+
+If you print your error message on more than one line manually, you will
+notice that the background is only as long as each individual line. Use the
+``format_block()`` method` to generate a block output:
+
+.. code-block:: python
+
+    error_messages = ['Error!', 'Something went wrong']
+    formatted_block = formatter.format_block(error_messages, 'error')
+    self.line(formatted_block)
+
+As you can see, passing an array of messages to the ``format_block()``
+method creates the desired output. If you pass ``True`` as third parameter, the
+block will be formatted with more padding (one blank line above and below the
+messages and 2 spaces on the left and right).
+
+The exact "style" you use in the block is up to you. In this case, you're using
+the pre-defined ``error`` style, but there are other styles, or you can create
+your own. See :ref:`output-coloring`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,3 +15,4 @@ with some useful additions.
     validators
     usage
     single_command_tool
+    api/index

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -102,6 +102,8 @@ The signature can span multiple lines.
         {--option : Option description}
     """
 
+.. _output-coloring:
+
 Coloring the Output
 ===================
 

--- a/docs/validators.rst
+++ b/docs/validators.rst
@@ -1,0 +1,115 @@
+Validators
+##########
+
+Validators are a convenient way to check and adapt the type of an argument or an option.
+
+.. code-block:: python
+
+    class GreetCommand(Command):
+        """
+        Greets someone
+
+        demo:greet {name? : Who do you want to greet?}
+                   {--y|yell : If set, will yell in uppercase letters}
+                   {--iterations=1 (integer) : How many times should the message be printed?}
+        """
+
+When using validators inside a command signature, only the :ref:`named_validators` are supported.
+Validators must be specified like so:
+
+.. code-block:: text
+
+    {argument_or_option (validator)}
+
+If you need more complex validators, or want to specify options to validators, you can do so by
+using the ``validation`` attribute:
+
+.. code-block:: python
+
+    class GreetCommand(Command):
+        """
+        Greets someone
+
+        demo:greet {name? : Who do you want to greet?}
+                   {--y|yell : If set, will yell in uppercase letters}
+                   {--iterations=1 : How many times should the message be printed?}
+        """
+
+        validation = {
+            '--iterations': Integer()
+        }
+
+For now, there are only a few built-in validators:
+
+.. note::
+
+    It is important to note that there is no ``String()`` validator. The reason is quite simple:
+    By default, the command line arguments and options are considered strings, so there is no need
+    to specify it.
+
+
+Integer and Float
+=================
+
+Those validators are self-explanatory.
+
+
+Boolean
+=======
+
+The ``Boolean()`` validator only accepts the following values: ``1``, ``true``, ``yes``, ``y``, ``on``
+and their negatives (``0``, ``no``, ``n``, ``off``) or native boolean types (``True``, ``False``).
+
+
+Range
+=====
+
+The ``Range()`` validator accepts a value that must be comprised inside a specified range.
+
+The range can be of anything that can be compared to the specified value, like integers, floats or string.
+
+The default validator for ranges is ``Integer`` but it can be changed.
+
+
+.. code-block:: python
+
+    # Not including the boundaries
+    Range(0, 6, include_min=False, include_max=False))
+
+    # Float validator
+    Range(12.34, 56.78, validator=Float())
+
+    # String validator (just pass None as validator value)
+    Range('c', 'h', validator=None)
+
+
+Choice/Enum
+===========
+
+The ``Choice()`` (or its alias ``Enum``) restricts a possible value to a specified set of choices.
+
+
+.. code-block:: python
+
+    Choice(['orange', 'blue', 'yellow'])
+
+    # With validator
+    Choice([1, 3, 5, 7, 11], validator=Integer())
+
+
+.. _named_validators:
+
+Named Validators
+================
+
+Instead of declaring explicitely the validators it is possible to use their internal names:
+
+    * ``Boolean``: ``boolean``
+    * ``Integer``: ``integer``
+    * ``Float``: ``boolean``
+    * ``Choice/Enum``: ``choice`` or ``enum``
+    * ``Range``: ``range``
+
+.. note::
+
+    When using named validators, the corresponding generated validator will have its default options.


### PR DESCRIPTION
# Issue

When building the docs, there are 3 warnings, this pull request fixes them.

```
$ make html
...
cleo/docs/index.rst:9: WARNING: toctree contains reference to nonexisting document 'validators'
...
checking consistency... cleo/docs/api/index.rst: WARNING: document isn't included in any toctree
...
cleo/docs/helpers/index.rst:7: WARNING: toctree contains reference to nonexisting document 'helpers/formatter_helper'
...
Build finished. The HTML pages are in _build/html.
```

# Fix

To address these warnings:

* I used `git bisect` to find the [commit that deleted `helpers/formatter_helper` and `validators`](https://github.com/python-poetry/cleo/commit/0e2e021d0295ec60d28387bda93f4885b83769f7), brought them back.
* I added a link to `api/index` from index.

You can see the rendered version on [readthedocs](https://cleo-canburak--3.org.readthedocs.build/en/3/).

# Open question
I don't know whether the resurrected content is preferable since the original commit doesn't have much to say.

If the PR is not helpful, let me know what to do, maybe just delete the broken links?

