### PR TITLE
chore: rename default branch to `main`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   Tests:
@@ -19,7 +19,7 @@ jobs:
           - os: Windows
             image: windows-2022
           - os: macOS
-            image: macos-12 
+            image: macos-12
     defaults:
       run:
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,7 @@ This is a major release with some API changes.
 
 
 
-[unreleased]: https://github.com/python-poetry/cleo/compare/0.8.1...master
+[unreleased]: https://github.com/python-poetry/cleo/compare/0.8.1...main
 [0.8.1]: https://github.com/python-poetry/cleo/releases/tag/0.8.1
 [0.8.0]: https://github.com/python-poetry/cleo/releases/tag/0.8.0
 [0.7.6]: https://github.com/python-poetry/cleo/releases/tag/0.7.6


### PR DESCRIPTION
`master` -> `main`
