### PR TITLE
feat: set `--no-interaction` when stdin is not a tty

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -501,7 +501,11 @@ class Application:
         elif io.input.has_parameter_option("--no-ansi", True):
             io.decorated(False)
 
-        if io.input.has_parameter_option(["--no-interaction", "-n"], True):
+        if io.input.has_parameter_option(["--no-interaction", "-n"], True) or (
+            io.input._interactive is None
+            and io.input.stream
+            and not io.input.stream.isatty()
+        ):
             io.interactive(False)
 
         shell_verbosity = int(os.getenv("SHELL_VERBOSITY", 0))

--- a/cleo/io/inputs/input.py
+++ b/cleo/io/inputs/input.py
@@ -21,7 +21,7 @@ class Input:
         self._stream: TextIO = None  # type: ignore[assignment]
         self._options: dict[str, Any] = {}
         self._arguments: dict[str, Any] = {}
-        self._interactive = True
+        self._interactive: bool | None = None
 
         if definition is None:
             self._definition = Definition()
@@ -56,7 +56,7 @@ class Input:
         """
         Reads the given amount of characters from the input stream.
         """
-        if not self._interactive:
+        if not self.is_interactive():
             return default
 
         return self._stream.read(length)
@@ -65,7 +65,7 @@ class Input:
         """
         Reads a line from the input stream.
         """
-        if not self._interactive:
+        if not self.is_interactive():
             return default
 
         return self._stream.readline(length)
@@ -83,7 +83,7 @@ class Input:
         return self._stream.closed
 
     def is_interactive(self) -> bool:
-        return self._interactive
+        return True if self._interactive is None else self._interactive
 
     def interactive(self, interactive: bool = True) -> None:
         self._interactive = interactive

--- a/cleo/testers/application_tester.py
+++ b/cleo/testers/application_tester.py
@@ -40,7 +40,7 @@ class ApplicationTester:
         self,
         args: str = "",
         inputs: str | None = None,
-        interactive: bool | None = None,
+        interactive: bool = True,
         verbosity: Verbosity | None = None,
         decorated: bool = False,
         supports_utf8: bool = True,


### PR DESCRIPTION
This infers `--no-interaction` when stdin is [not a TTY](https://docs.python.org/3/library/io.html#io.IOBase.isatty)

Before:

```console
$ : | poetry cache clear --all .
Delete 615 entries? (yes/no) [no]
Aborted
```

After:

```console
$ : | poetry cache clear --all .
```

Fixes #232
