### PR TITLE
fix incompatible zsh syntax used in bash

### DIFF
--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -164,7 +164,7 @@ script. Consult your shells documentation for how to add such directives.
                 for opt in sorted(cmd.definition.options, key=lambda o: o.name)
             )
             cmds_opts += [
-                f"            ({command_name})",
+                f"            {command_name})",
                 f'            opts="${{opts}} {options}"',
                 "            ;;",
                 "",  # newline

--- a/tests/commands/completion/fixtures/bash.txt
+++ b/tests/commands/completion/fixtures/bash.txt
@@ -25,23 +25,23 @@ _my_function()
 
         case "$com" in
 
-            (command:with:colons)
+            command:with:colons)
             opts="${opts} --goodbye"
             ;;
 
-            (hello)
+            hello)
             opts="${opts} --dangerous-option --option-without-description"
             ;;
 
-            (help)
+            help)
             opts="${opts} "
             ;;
 
-            (list)
+            list)
             opts="${opts} "
             ;;
 
-            ('spaced command')
+            'spaced command')
             opts="${opts} "
             ;;
 


### PR DESCRIPTION
bash can't use 
```bash
case EXPRESSION in (case) COMMAND-LIST;; ... esac
                   ^
                    '- invalid syntax
```
bash case grammar:
```
case EXPRESSION in CASE1) COMMAND-LIST;; CASE2) COMMAND-LIST;; ... CASEN) COMMAND-LIST;; esac
```

It's probably mistaken for zsh syntax:
```
case word in [ [(] pattern [ | pattern ] ... ) list (;;|;&|;|) ] ... esac
```

---
Sources:
* [bash grammar source](https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_07_03.html)
* [zsh grammar source](https://zsh.sourceforge.io/Doc/Release/Shell-Grammar.html)