### PR TITLE
CompletionsCommand - fix fish completions

### DIFF
--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -249,7 +249,7 @@ script. Consult your shells documentation for how to add such directives.
             command_name = shell_quote(cmd.name) if " " in cmd.name else cmd.name
             cmds.append(
                 f"complete -c {script_name} -f -n '__fish{function}_no_subcommand' "
-                f"-a '{command_name}' -d '{sanitize(cmd.description)}'"
+                f"-a '{cmd.name}' -d '{sanitize(cmd.description)}'"
             )
             cmds_opts += [
                 f"# {command_name}",

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -249,7 +249,7 @@ script. Consult your shells documentation for how to add such directives.
             command_name = shell_quote(cmd.name) if " " in cmd.name else cmd.name
             cmds.append(
                 f"complete -c {script_name} -f -n '__fish{function}_no_subcommand' "
-                f"-a {command_name} -d '{sanitize(cmd.description)}'"
+                f"-a '{command_name}' -d '{sanitize(cmd.description)}'"
             )
             cmds_opts += [
                 f"# {command_name}",

--- a/tests/commands/completion/fixtures/fish.txt
+++ b/tests/commands/completion/fixtures/fish.txt
@@ -17,10 +17,10 @@ complete -c script -n '__fish_my_function_no_subcommand' -l verbose -d 'Increase
 complete -c script -n '__fish_my_function_no_subcommand' -l version -d 'Display this application version.'
 
 # commands
-complete -c script -f -n '__fish_my_function_no_subcommand' -a command:with:colons -d 'Test.'
-complete -c script -f -n '__fish_my_function_no_subcommand' -a hello -d 'Complete me please.'
-complete -c script -f -n '__fish_my_function_no_subcommand' -a help -d 'Displays help for a command.'
-complete -c script -f -n '__fish_my_function_no_subcommand' -a list -d 'Lists commands.'
+complete -c script -f -n '__fish_my_function_no_subcommand' -a 'command:with:colons' -d 'Test.'
+complete -c script -f -n '__fish_my_function_no_subcommand' -a 'hello' -d 'Complete me please.'
+complete -c script -f -n '__fish_my_function_no_subcommand' -a 'help' -d 'Displays help for a command.'
+complete -c script -f -n '__fish_my_function_no_subcommand' -a 'list' -d 'Lists commands.'
 complete -c script -f -n '__fish_my_function_no_subcommand' -a 'spaced command' -d 'Command with space in name.'
 
 # command options


### PR DESCRIPTION
The generated completions for the fish shell contained unescaped spaces in the arguments for the `-a` options, causing the completions to partially fail (see screenshot below).

<img width="682" alt="Screenshot 2022-10-16 at 17 29 47" src="https://user-images.githubusercontent.com/5142004/196043978-539985b0-fb6e-4469-8a99-0f8a8de03878.png">

The pull updates the template for the fish completions to `-a '{command_name}'`.