### PR TITLE
Change -dev to full Python 3.11 version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: Ubuntu
             image: ubuntu-22.04
@@ -67,11 +67,6 @@ jobs:
           [ "$(command -v timeout)" ] || function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
           # Using `timeout` is a safeguard against the Poetry command hanging for some reason.
           timeout 10s poetry run pip --version || rm -rf .venv
-
-      # XXX: https://github.com/pypa/pip/issues/11352 causes random failures -- remove once fixed in a release.
-      - name: Upgrade pip on 3.11 for macOS
-        if: ${{ matrix.python-version == '3.11-dev' && matrix.os == 'macOS' }}
-        run: poetry run pip install git+https://github.com/pypa/pip.git@fbb7f0b293f1d9289d8c76a556540325b9a172b2
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
As in the title, this PR removes the `-dev` part from Python 3.11 version in CI. This also removes the `pip` patch which is no longer needed, since Python 3.11 ships with a new `pip` version, which has the patch included.