### PR TITLE
Use env vars for exporting output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  Linux:
+  Build:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,11 +15,13 @@ jobs:
     - name: Get tag
       id: tag
       run: |
-        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        echo tag=${GITHUB_REF#refs/tags/} >> $GITHUB_OUTPUT
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+
     - name: Install and set up Poetry
       run: |
         curl -sL https://install.python-poetry.org | python - -y
@@ -38,8 +40,8 @@ jobs:
         name: project-dist
         path: dist
 
-  Release:
-    needs: [Linux]
+  Publish:
+    needs: [Build]
     runs-on: ubuntu-latest
 
     steps:
@@ -48,12 +50,14 @@ jobs:
       - name: Get tag
         id: tag
         run: |
-          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+          echo tag=${GITHUB_REF#refs/tags/} >> $GITHUB_OUTPUT
+
       - name: Download distribution artifact
         uses: actions/download-artifact@master
         with:
           name: project-dist
           path: dist
+
       - name: Install and set up Poetry
         run: |
           curl -sL https://install.python-poetry.org | python - -y

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get full python version
         id: full-python-version
         run: |
-          echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+          echo version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))") >> $GITHUB_OUTPUT
 
       - name: Install Poetry
         run: |


### PR DESCRIPTION
`set-output` is now deprecated.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ shows the new way of exporting outputs.

Also changed the formatting in the release action and renamed the steps to be more verbose.