### PR TITLE
Implement ruff checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,8 @@
 [flake8]
 min_python_version = 3.7.0
 max-line-length = 88
-ban-relative-imports = true
 # flake8-use-fstring: https://github.com/MichaelKim0407/flake8-use-fstring#--percent-greedy-and---format-greedy
 format-greedy = 1
-inline-quotes = double
 enable-extensions = TC, TC1
 type-checking-exempt-modules = typing, typing-extensions
 eradicate-whitelist-extend = ^-.*;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,19 +31,19 @@ repos:
       - id: yesqa
         additional_dependencies: &flake8_deps
           - flake8-broken-line==0.6.0
-          - flake8-bugbear==22.10.27
-          - flake8-comprehensions==3.10.1
           - flake8-eradicate==1.4.0
-          - flake8-quotes==3.3.1
           - flake8-simplify==0.19.3
-          - flake8-tidy-imports==4.8.0
           - flake8-type-checking==2.2.0
           - flake8-typing-imports==1.14.0
           - flake8-use-fstring==1.4
-          - pep8-naming==0.13.2
 
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: *flake8_deps
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.138
+    hooks:
+    -   id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,10 +30,7 @@ repos:
     hooks:
       - id: yesqa
         additional_dependencies: &flake8_deps
-          - flake8-broken-line==0.6.0
-          - flake8-eradicate==1.4.0
           - flake8-simplify==0.19.3
-          - flake8-type-checking==2.2.0
           - flake8-typing-imports==1.14.0
           - flake8-use-fstring==1.4
 
@@ -44,6 +41,6 @@ repos:
         additional_dependencies: *flake8_deps
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.138
+    rev: v0.0.230
     hooks:
     -   id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,26 @@ mypy = "^0.990"
 Sphinx = "^5.2.3"
 sphinx-rtd-theme = "^1.0.0"
 
+[tool.ruff]
+fix = true
+target-version = "py37"
+line-length = 88
+extend-exclude = [
+    "docs/*",
+]
+ignore = [
+    # ruff is not the same as isort, might change in the future
+    "I",
+    # exclude documentation checks until https://github.com/python-poetry/cleo/issues/251 is worked on
+    "D",
+]
+
+[tool.ruff.flake8-quotes]
+inline-quotes = "double"
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
 [tool.isort]
 profile = "black"
 force_single_line = true


### PR DESCRIPTION
Gradual migration to a `ruff` linter. The flake8 plugins that don't have counterparts in `ruff` are still checked by flake8 until they are not implemented.