### PR TITLE
Sanitize command name in fish shell generated completion file

### DIFF
--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -255,7 +255,7 @@ script. Consult your shells documentation for how to add such directives.
                 f"# {command_name}",
                 *[
                     f"complete -c {script_name} -A "
-                    f"-n '__fish_seen_subcommand_from {command_name}' "
+                    f"-n '__fish_seen_subcommand_from {sanitize(command_name)}' "
                     f"-l {opt.name} -d '{sanitize(opt.description)}'"
                     for opt in sorted(cmd.definition.options, key=lambda o: o.name)
                 ],

--- a/tests/commands/completion/fixtures/bash.txt
+++ b/tests/commands/completion/fixtures/bash.txt
@@ -42,7 +42,7 @@ _my_function()
             ;;
 
             ('spaced command')
-            opts="${opts} "
+            opts="${opts} --goodbye"
             ;;
 
         esac

--- a/tests/commands/completion/fixtures/command_with_space_in_name.py
+++ b/tests/commands/completion/fixtures/command_with_space_in_name.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from cleo.commands.command import Command
 from cleo.helpers import argument
+from cleo.helpers import option
 
 
 class SpacedCommand(Command):
     name = "spaced command"
     description = "Command with space in name."
     arguments = [argument("test", description="test argument")]
+    options = [option("goodbye")]

--- a/tests/commands/completion/fixtures/fish.txt
+++ b/tests/commands/completion/fixtures/fish.txt
@@ -37,4 +37,4 @@ complete -c script -A -n '__fish_seen_subcommand_from hello' -l option-without-d
 # list
 
 # 'spaced command'
-complete -c script -A -n '__fish_seen_subcommand_from 'spaced command'' -l goodbye -d ''
+complete -c script -A -n '__fish_seen_subcommand_from \'spaced command\'' -l goodbye -d ''

--- a/tests/commands/completion/fixtures/fish.txt
+++ b/tests/commands/completion/fixtures/fish.txt
@@ -37,3 +37,4 @@ complete -c script -A -n '__fish_seen_subcommand_from hello' -l option-without-d
 # list
 
 # 'spaced command'
+complete -c script -A -n '__fish_seen_subcommand_from 'spaced command'' -l goodbye -d ''

--- a/tests/commands/completion/fixtures/zsh.txt
+++ b/tests/commands/completion/fixtures/zsh.txt
@@ -48,7 +48,7 @@ _my_function()
             ;;
 
             ('spaced command')
-            opts+=()
+            opts+=("--goodbye")
             ;;
 
             esac


### PR DESCRIPTION
## Description of the problem

This P.R tries to fix the behavior described in [poetry's Fish completions raise errors but still works](https://github.com/python-poetry/poetry/issues/5929#issuecomment-1345580021) issue.

### Software versions

I'm running

```
❯ pip freeze |grep -E 'poetry|cleo'
cleo==2.0.1
poetry==1.3.1
poetry-core==1.4.0
poetry-plugin-export==1.2.0
```

```
❯ python -V
Python 3.10.6
```

## Description of the patch

A `--goodbye` option was added to the `spaced command` in the `cleo` test suite. Adding this option mimics the problem described in [poetry's Fish completions raise errors but still works](https://github.com/python-poetry/poetry/issues/5929#issuecomment-1345580021) issue.

`fish` shell fixture was modified to what I consider a valid solution to the problem.

Generated `fish` completion file before and after the patch:

**before the patch**

```
[...]
complete -c script -A -n '__fish_seen_subcommand_from 'spaced command'' -l goodbye -d ''
[...]
```

**after the patch**

```
[...]
complete -c script -A -n '__fish_seen_subcommand_from \'spaced command\'' -l goodbye -d ''
[...]
```

Modified test suite passes successfully.

```
❯ poetry run pytest -q tests
[...]
246 passed, 1 skipped in 5.37s
```

I've tested this patch to generate the `poetry` `fish` completion file and it seems to solve the problem.