### PR TITLE
fix: avoid zerodivisionerrors in no-tty usecase

### DIFF
--- a/src/cleo/io/outputs/section_output.py
+++ b/src/cleo/io/outputs/section_output.py
@@ -67,7 +67,7 @@ class SectionOutput(StreamOutput):
             self._lines += (
                 math.ceil(
                     len(self.remove_format(line_content).replace("\t", "        "))
-                    / self._terminal.columns
+                    / (self._terminal.columns or 1)
                 )
                 or 1
             )

--- a/src/cleo/ui/progress_bar.py
+++ b/src/cleo/ui/progress_bar.py
@@ -314,11 +314,9 @@ class ProgressBar(Component):
             if self._previous_message is not None:
                 if isinstance(self._io, SectionOutput):
                     lines_to_clear = (
-                        int(
-                            math.floor(
-                                len(self._io.remove_format(message))
-                                / self._terminal.columns
-                            )
+                        (
+                            len(self._io.remove_format(message))
+                            // (self._terminal.columns or 1)
                         )
                         + self._format_line_count
                         + 1


### PR DESCRIPTION
Fix for python-poetry/poetry#7184, which discovered that this would
lead to ZeroDivisionErrors as `columns` will be `0` for Python <3.11
running without a TTY.
