### PR TITLE
Fix terminal size detection

### DIFF
--- a/news/299.bugfix.md
+++ b/news/299.bugfix.md
@@ -1,0 +1,1 @@
+Fixed terminal size detection.

--- a/src/cleo/application.py
+++ b/src/cleo/application.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import re
-import shutil
 import sys
 
 from contextlib import suppress
@@ -30,6 +29,7 @@ from cleo.io.inputs.option import Option
 from cleo.io.io import IO
 from cleo.io.outputs.output import Verbosity
 from cleo.io.outputs.stream_output import StreamOutput
+from cleo.terminal import Terminal
 from cleo.ui.ui import UI
 
 
@@ -61,7 +61,7 @@ class Application:
         self._name = name
         self._version = version
         self._display_name: str | None = None
-        self._terminal = shutil.get_terminal_size()
+        self._terminal = Terminal().size
         self._default_command = "list"
         self._single_command = False
         self._commands: dict[str, Command] = {}

--- a/src/cleo/io/outputs/section_output.py
+++ b/src/cleo/io/outputs/section_output.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import math
-import shutil
 
 from typing import TYPE_CHECKING
 from typing import TextIO
 
 from cleo.io.outputs.output import Verbosity
 from cleo.io.outputs.stream_output import StreamOutput
+from cleo.terminal import Terminal
 
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class SectionOutput(StreamOutput):
         self._lines = 0
         sections.insert(0, self)
         self._sections = sections
-        self._terminal = shutil.get_terminal_size()
+        self._terminal = Terminal().size
 
     @property
     def content(self) -> str:
@@ -67,7 +67,7 @@ class SectionOutput(StreamOutput):
             self._lines += (
                 math.ceil(
                     len(self.remove_format(line_content).replace("\t", "        "))
-                    / self._terminal.columns
+                    / self._terminal.width
                 )
                 or 1
             )

--- a/src/cleo/terminal.py
+++ b/src/cleo/terminal.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from typing import NamedTuple
+
+
+class TerminalSize(NamedTuple):
+    width: int
+    height: int
+
+
+class Terminal:
+    def __init__(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        fallback: tuple[int, int] | None = None,
+    ) -> None:
+        self._width = width
+        self._height = height
+        self._fallback = TerminalSize(*(fallback if fallback is not None else (80, 25)))
+
+    @property
+    def width(self) -> int:
+        return self.size.width
+
+    @property
+    def height(self) -> int:
+        return self.size.height
+
+    @property
+    def size(self) -> TerminalSize:
+        return self._get_terminal_size()
+
+    def _get_terminal_size(self) -> TerminalSize:
+        if self._width is not None and self._height is not None:
+            return TerminalSize(self._width, self._height)
+
+        width = 0
+        height = 0
+
+        columns = os.environ.get("COLUMNS")
+        if columns is not None and columns.isdigit():
+            width = int(columns)
+        lines = os.environ.get("LINES")
+        if lines is not None and lines.isdigit():
+            height = int(lines)
+
+        if width <= 0 or height <= 0:
+            try:
+                os_size = os.get_terminal_size(sys.__stdout__.fileno())
+                size = TerminalSize(*os_size)
+            except (AttributeError, ValueError, OSError):
+                # stdout is None, closed, detached, or not a terminal, or
+                # os.get_terminal_size() is unsupported # noqa: ERA001
+                size = self._fallback
+            if width <= 0:
+                width = size.width or self._fallback.width
+            if height <= 0:
+                height = size.height or self._fallback.height
+
+        return TerminalSize(
+            width if self._width is None else self._width,
+            height if self._height is None else self._height,
+        )

--- a/src/cleo/ui/progress_bar.py
+++ b/src/cleo/ui/progress_bar.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 import re
-import shutil
 import time
 
 from typing import TYPE_CHECKING
@@ -12,6 +11,7 @@ from cleo._utils import format_time
 from cleo.cursor import Cursor
 from cleo.io.io import IO
 from cleo.io.outputs.section_output import SectionOutput
+from cleo.terminal import Terminal
 from cleo.ui.component import Component
 
 
@@ -57,7 +57,7 @@ class ProgressBar(Component):
             io = io.error_output
 
         self._io = io
-        self._terminal = shutil.get_terminal_size()
+        self._terminal = Terminal().size
         self._max = 0
         self._step_width: int = 1
         self._set_max_steps(max)
@@ -317,7 +317,7 @@ class ProgressBar(Component):
                         int(
                             math.floor(
                                 len(self._io.remove_format(message))
-                                / self._terminal.columns
+                                / self._terminal.width
                             )
                         )
                         + self._format_line_count
@@ -443,7 +443,7 @@ class ProgressBar(Component):
 
         lines_width = max(lines_length)
 
-        terminal_width = self._terminal.columns
+        terminal_width = self._terminal.width
 
         if lines_width <= terminal_width:
             return line

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cleo.terminal import Terminal
+
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def test_size() -> None:
+    terminal = Terminal()
+    w, h = terminal.size
+    assert terminal.width == w
+
+    terminal = Terminal(width=99, height=101)
+    w, h = terminal.size
+    assert w == 99 and h == 101
+
+
+@pytest.mark.parametrize(
+    "columns_env_value, init_value, expected",
+    (
+        ("314", None, 314),
+        ("200", 40, 40),
+        ("random", 40, 40),
+        ("random", None, 80),
+    ),
+)
+def test_columns_env(
+    mocker: MockerFixture, columns_env_value: str, init_value: int | None, expected: int
+) -> None:
+    mocker.patch.dict(os.environ, {"COLUMNS": columns_env_value}, clear=False)
+    console = Terminal(width=init_value)
+    assert console.width == expected
+
+
+@pytest.mark.parametrize(
+    "lines_env_value, init_value, expected",
+    (
+        ("314", None, 314),
+        ("200", 40, 40),
+        ("random", 40, 40),
+        ("random", None, 25),
+    ),
+)
+def test_lines_env(
+    mocker: MockerFixture, lines_env_value: str, init_value: int | None, expected: int
+) -> None:
+    mocker.patch.dict(os.environ, {"LINES": lines_env_value}, clear=False)
+    console = Terminal(height=init_value)
+    assert console.height == expected


### PR DESCRIPTION
Closes: python-poetry/poetry#7184

This fixes the issue, where in Python <3.11 `shutil.get_terminal_size()` would return `(0, 0)` size in non-TTY terminals.