### PR TITLE
(🐞) stream_output: correctly handle virtual terminal ANSI support

### DIFF
--- a/news/313.bugfix.md
+++ b/news/313.bugfix.md
@@ -1,0 +1,1 @@
+Fixed ANSI coloring detection in virtual terminal environments (Windows, PyCharm)

--- a/src/cleo/io/outputs/stream_output.py
+++ b/src/cleo/io/outputs/stream_output.py
@@ -135,13 +135,16 @@ class StreamOutput(Output):
             if not kernel32.GetConsoleMode(h, ctypes.byref(mode)):
                 return False
 
-            if (mode.value & self.ENABLE_VIRTUAL_TERMINAL_PROCESSING) == 0:
+            if (mode.value & self.ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0:
+                return True
+
+            result: bool = (
                 kernel32.SetConsoleMode(
                     h, mode.value | self.ENABLE_VIRTUAL_TERMINAL_PROCESSING
                 )
-                return True
-
-            return False
+                != 0
+            )
+            return result
 
         if not hasattr(self._stream, "fileno"):
             return False


### PR DESCRIPTION
Credit to @TBBle for this fix in #104

- resolves #104
- resolves https://github.com/python-poetry/poetry/issues/1972
- resolves https://github.com/python-poetry/poetry/issues/3354

Poetry output before and after this change:
![image](https://user-images.githubusercontent.com/65446343/231679703-b0108ae5-d646-44ec-9880-2857ae43c9e3.png)
