### PR TITLE
chore: expand ruff usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,6 @@ ci:
   autofix_prs: false
 
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py37-plus
-
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.3
-    hooks:
-      - id: pycln
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        exclude: ^tests/fixtures/exceptions/
-
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
@@ -28,4 +10,4 @@ repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.265
     hooks:
-    -   id: ruff
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,44 +53,39 @@ sphinx-rtd-theme = "^1.0.0"
 
 [tool.ruff]
 fix = true
+unfixable = [
+    "ERA", # do not autoremove commented out code
+]
 target-version = "py37"
 line-length = 88
 extend-select = [
-    "B",  # flake8-bugbear
+    "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
-    "ERA",  # flake8-eradicate/eradicate
-    "PIE",  # flake8-pie
-    "SIM",  # flake8-simplify
-    "TID",  # flake8-tidy-imports
-    "TCH",  # flake8-type-checking
-    "N",  # pep8-naming
-    "RUF",  # ruff checks
+    "ERA", # flake8-eradicate/eradicate
+    "I",   # isort
+    "N",   # pep8-naming
+    "PIE", # flake8-pie
+    "PGH", # pygrep
+    "RUF", # ruff checks
+    "SIM", # flake8-simplify
+    "TCH", # flake8-type-checking
+    "TID", # flake8-tidy-imports
+    "UP",  # pyupgrade
 ]
 extend-exclude = [
     "docs/*",
+    "tests/fixtures/exceptions/*"
 ]
 
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.isort]
-profile = "black"
-force_single_line = true
-atomic = true
-lines_after_imports = 2
-lines_between_types = 1
-src_paths = [
-    "src",
-    "tests"
-]
-add_imports = [
-    "from __future__ import annotations"
-]
-filter_files = true
-known_first_party = "cleo"
-
-[tool.pycln]
-all = true
+[tool.ruff.isort]
+force-single-line = true
+lines-between-types = 1
+lines-after-imports = 2
+known-first-party = ["cleo"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
Replaces `pyupgrade`, `pycln`, and `isort` with `ruff` (same as https://github.com/python-poetry/poetry/pull/7850)

Config was also copied from poetry
