### PR TITLE
Improved string styling

### DIFF
--- a/news/344.misc.md
+++ b/news/344.misc.md
@@ -1,0 +1,1 @@
+Improved string styling

--- a/news/344.misc.md
+++ b/news/344.misc.md
@@ -1,1 +1,0 @@
-Improved string styling

--- a/src/cleo/color.py
+++ b/src/cleo/color.py
@@ -55,7 +55,7 @@ class Color:
             if option not in self.AVAILABLE_OPTIONS:
                 raise ValueError(
                     f'"{option}" is not a valid color option. '
-                    f"It must be one of {', '.join(self.AVAILABLE_OPTIONS)}"
+                    f"It must be one of {', '.join(self.AVAILABLE_OPTIONS.keys())}"
                 )
 
             self._options[option] = self.AVAILABLE_OPTIONS[option]

--- a/src/cleo/color.py
+++ b/src/cleo/color.py
@@ -55,7 +55,7 @@ class Color:
             if option not in self.AVAILABLE_OPTIONS:
                 raise ValueError(
                     f'"{option}" is not a valid color option. '
-                    f'It must be one of {", ".join(self.AVAILABLE_OPTIONS.keys())}'
+                    f"It must be one of {', '.join(self.AVAILABLE_OPTIONS)}"
                 )
 
             self._options[option] = self.AVAILABLE_OPTIONS[option]
@@ -78,7 +78,7 @@ class Color:
         if not codes:
             return ""
 
-        return f'\033[{";".join(codes)}m'
+        return f"\033[{';'.join(codes)}m"
 
     def unset(self) -> str:
         codes = []
@@ -95,7 +95,7 @@ class Color:
         if not codes:
             return ""
 
-        return f'\033[{";".join(codes)}m'
+        return f"\033[{';'.join(codes)}m"
 
     def _parse_color(self, color: str, background: bool) -> str:
         if not color:
@@ -117,7 +117,7 @@ class Color:
         if color not in self.COLORS:
             raise CleoValueError(
                 f'"{color}" is an invalid color.'
-                f' It must be one of {", ".join(self.COLORS.keys())}'
+                f" It must be one of {', '.join(self.COLORS.keys())}"
             )
 
         return str(self.COLORS[color][int(background)])

--- a/src/cleo/commands/command.py
+++ b/src/cleo/commands/command.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
         return self._io.input.option(name)
 
     def confirm(
-        self, question: str, default: bool = False, true_answer_regex: str = "(?i)^y"
+        self, question: str, default: bool = False, true_answer_regex: str = r"(?i)^y"
     ) -> bool:
         """
         Confirm a question with the user.

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -297,7 +297,7 @@ script. Consult your shells documentation for how to add such directives.
     def _sanitize_for_function_name(self, name: str) -> str:
         name = name.replace("-", "_")
 
-        return re.sub("[^A-Za-z0-9_]+", "", name)
+        return re.sub(r"[^A-Za-z0-9_]+", "", name)
 
     def _zsh_describe(self, value: str, description: str | None = None) -> str:
         value = '"' + value.replace(":", "\\:")

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -303,7 +303,7 @@ script. Consult your shells documentation for how to add such directives.
         value = '"' + value.replace(":", "\\:")
         if description:
             description = re.sub(
-                r'(["\'#&;`|*?~<>^()\[\]{}$\\\x0A\xFF])', r"\\\1", description
+                r"([\"'#&;`|*?~<>^()\[\]{}$\\\x0A\xFF])", r"\\\1", description
             )
             value += ":" + subprocess.list2cmdline([description]).strip('"')
 

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -120,7 +120,7 @@ script. Consult your shells documentation for how to add such directives.
 
         if shell not in self.SUPPORTED_SHELLS:
             raise ValueError(
-                f'[shell] argument must be one of {", ".join(self.SUPPORTED_SHELLS)}'
+                f"[shell] argument must be one of {', '.join(self.SUPPORTED_SHELLS)}"
             )
 
         self.line(self.render(shell))

--- a/src/cleo/descriptors/text_descriptor.py
+++ b/src/cleo/descriptors/text_descriptor.py
@@ -40,7 +40,7 @@ class TextDescriptor(Descriptor):
             argument.description,
         )
         self._write(
-            f'  <c1>{argument.name}</c1>  {" " * spacing_width}'
+            f"  <c1>{argument.name}</c1>  {' ' * spacing_width}"
             f"{sub_argument_description}{default}"
         )
 
@@ -82,7 +82,7 @@ class TextDescriptor(Descriptor):
         )
         self._write(
             f"  <c1>{synopsis}</c1>  "
-            f'{" " * spacing_width}{sub_option_description}'
+            f"{' ' * spacing_width}{sub_option_description}"
             f"{default}"
             f"{are_multiple_values_allowed}"
         )
@@ -204,7 +204,7 @@ class TextDescriptor(Descriptor):
                 and namespace["id"] != ApplicationDescription.GLOBAL_NAMESPACE
             ):
                 self._write("\n")
-                self._write(f' <comment>{namespace["id"]}</comment>')
+                self._write(f" <comment>{namespace['id']}</comment>")
 
             for name in namespace["commands"]:
                 self._write("\n")
@@ -216,7 +216,7 @@ class TextDescriptor(Descriptor):
                     else ""
                 )
                 self._write(
-                    f'  <c1>{name}</c1>{" " * spacing_width}'
+                    f"  <c1>{name}</c1>{' ' * spacing_width}"
                     f"{command_aliases + command.description}"
                 )
 
@@ -282,6 +282,6 @@ class TextDescriptor(Descriptor):
         aliases = command.aliases
 
         if aliases:
-            text = f'[{ "|".join(aliases) }] '
+            text = f"[{ '|'.join(aliases) }] "
 
         return text

--- a/src/cleo/formatters/formatter.py
+++ b/src/cleo/formatters/formatter.py
@@ -146,7 +146,7 @@ class Formatter:
         if string in self._inline_styles_cache:
             return self._inline_styles_cache[string]
 
-        matches = re.findall("([^=]+)=([^;]+)(;|$)", string.lower())
+        matches = re.findall(r"([^=]+)=([^;]+)(;|$)", string.lower())
         if not matches:
             return None
 

--- a/src/cleo/ui/choice_question.py
+++ b/src/cleo/ui/choice_question.py
@@ -35,7 +35,7 @@ class SelectChoiceValidator:
         if self._question.supports_multiple_choices():
             # Check for a separated comma values
             _selected = selected.replace(" ", "")
-            if not re.match("^[a-zA-Z0-9_-]+(?:,[a-zA-Z0-9_-]+)*$", _selected):
+            if not re.match(r"^[a-zA-Z0-9_-]+(?:,[a-zA-Z0-9_-]+)*$", _selected):
                 raise CleoValueError(self._question.error_message.format(selected))
 
             selected_choices = _selected.split(",")

--- a/src/cleo/ui/choice_question.py
+++ b/src/cleo/ui/choice_question.py
@@ -53,7 +53,7 @@ class SelectChoiceValidator:
             if len(results) > 1:
                 raise CleoValueError(
                     "The provided answer is ambiguous. "
-                    f'Value should be one of {" or ".join(str(r) for r in results)}.'
+                    f"Value should be one of {' or '.join(str(r) for r in results)}."
                 )
 
             if value in self._values:
@@ -123,7 +123,7 @@ class ChoiceQuestion(Question):
 
             message = (
                 f"<question>{message}</question> "
-                f'[<comment>{", ".join(default)}</comment>]:'
+                f"[<comment>{', '.join(default)}</comment>]:"
             )
         else:
             choices = self._choices

--- a/src/cleo/ui/confirmation_question.py
+++ b/src/cleo/ui/confirmation_question.py
@@ -17,7 +17,7 @@ class ConfirmationQuestion(Question):
     """
 
     def __init__(
-        self, question: str, default: bool = True, true_answer_regex: str = "(?i)^y"
+        self, question: str, default: bool = True, true_answer_regex: str = r"(?i)^y"
     ) -> None:
         super().__init__(question, default)
 

--- a/src/cleo/ui/exception_trace.py
+++ b/src/cleo/ui/exception_trace.py
@@ -182,7 +182,7 @@ class Highlighter:
         max_line_length = max(3, len(str(len(lines))))
 
         snippet_lines = []
-        marker = f'<{self._theme[self.LINE_MARKER]}>{self._ui["arrow"]}</> '
+        marker = f"<{self._theme[self.LINE_MARKER]}>{self._ui['arrow']}</> "
         no_marker = "  "
         for i, line in enumerate(lines):
             snippet = ""
@@ -198,7 +198,7 @@ class Highlighter:
             snippet += (
                 f"<{styling}>"
                 f"{line_number}</><{self._theme[self.LINE_NUMBER]}>"
-                f'{self._ui["delimiter"]}</> {line}'
+                f"{self._ui['delimiter']}</> {line}"
             )
             snippet_lines.append(snippet)
 
@@ -321,7 +321,7 @@ class ExceptionTrace:
             self._render_line(
                 io,
                 f"<fg=blue;options=bold>{symbol} </>"
-                f'<fg=default;options=bold>{title.rstrip(".")}</>:'
+                f"<fg=default;options=bold>{title.rstrip('.')}</>:"
                 f" {description}{joined_links}",
                 True,
             )
@@ -353,7 +353,7 @@ class ExceptionTrace:
 
                     self._render_line(
                         io,
-                        f'<fg=blue>{"...":>{max_frame_length}}</>  '
+                        f"<fg=blue>{'...':>{max_frame_length}}</>  "
                         f"Previous {frames_message} repeated "
                         f"<fg=blue>{collection.repetitions + 1}</> times",
                         True,
@@ -397,7 +397,7 @@ class ExceptionTrace:
                         for code_line in code_lines:
                             self._render_line(
                                 io,
-                                f'{" ":>{max_frame_length}}{code_line}',
+                                f"{' ':>{max_frame_length}}{code_line}",
                                 indent=3,
                             )
                     else:
@@ -410,7 +410,7 @@ class ExceptionTrace:
                             code_line = frame.line.strip()
 
                         self._render_line(
-                            io, f'{" ":>{max_frame_length}}    {code_line}'
+                            io, f"{' ':>{max_frame_length}}    {code_line}"
                         )
 
                     i -= 1
@@ -421,7 +421,7 @@ class ExceptionTrace:
         if new_line:
             io.write_line("")
 
-        io.write_line(f'{indent * " "}{line}')
+        io.write_line(f"{indent * ' '}{line}")
 
     def _get_relative_file_path(self, filepath: str) -> str:
         cwd = os.getcwd()

--- a/src/cleo/ui/table_cell_style.py
+++ b/src/cleo/ui/table_cell_style.py
@@ -39,7 +39,7 @@ class TableCellStyle:
         tag = "<fg={};bg={}"
 
         if self._options:
-            tag += f';options={",".join(self._options)}'
+            tag += f";options={','.join(self._options)}"
 
         tag += ">"
 

--- a/tests/ui/test_confirmation_question.py
+++ b/tests/ui/test_confirmation_question.py
@@ -31,8 +31,8 @@ def test_ask(io: BufferedIO, input: str, expected: bool, default: bool) -> None:
 def test_ask_with_custom_answer(io: BufferedIO) -> None:
     io.set_user_input("j\ny\n")
 
-    question = ConfirmationQuestion("Do you like French fries?", False, "(?i)^(j|y)")
+    question = ConfirmationQuestion("Do you like French fries?", False, r"(?i)^(j|y)")
     assert question.ask(io)
 
-    question = ConfirmationQuestion("Do you like French fries?", False, "(?i)^(j|y)")
+    question = ConfirmationQuestion("Do you like French fries?", False, r"(?i)^(j|y)")
     assert question.ask(io)

--- a/tests/ui/test_exception_trace.py
+++ b/tests/ui/test_exception_trace.py
@@ -181,7 +181,7 @@ def test_render_can_ignore_given_files() -> None:
         nested2.call()
 
     trace = ExceptionTrace(e.value)
-    trace.ignore_files_in(f"^{re.escape(nested1.__file__)}$")
+    trace.ignore_files_in(rf"^{re.escape(nested1.__file__)}$")
     trace.render(io)
 
     lineno = 181
@@ -219,7 +219,7 @@ def test_render_shows_ignored_files_if_in_debug_mode() -> None:
         nested2.call()
 
     trace = ExceptionTrace(e.value)
-    trace.ignore_files_in(f"^{re.escape(nested1.__file__)}$")
+    trace.ignore_files_in(rf"^{re.escape(nested1.__file__)}$")
 
     trace.render(io)
     lineno = 219


### PR DESCRIPTION
- Made f-strings use outer double quotes when doing interpolation (probably ignored by a formatter), e.g.
  ```diff
  -f' It must be one of {", ".join(self.COLORS.keys())}'
  +f" It must be one of {', '.join(self.COLORS.keys())}"
  ```
- Flipped quotes for a raw string using both inside:
  ```diff
  -r'a\'"z'
  +r"a'\"z"
  ```
- Made all RegEx strings raw strings, e.g.
  ```diff
  -"(?i)^y"
  +r"(?i)^y"
  ```