### PR TITLE
test: speed up test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
         os: [Ubuntu, macOS, Windows]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
+          - python-version: "3.7"
+            install-args: --version=1.5.1
           - os: Ubuntu
             image: ubuntu-22.04
           - os: Windows
@@ -39,7 +41,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sL https://install.python-poetry.org | python - -y
+          curl -sL https://install.python-poetry.org | python - -y ${{ matrix.install-args }}
 
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,10 @@ from cleo.io.inputs.string_input import StringInput
 
 
 if TYPE_CHECKING:
+    from typing import Callable
     from typing import Iterator
+
+    from pytest_mock import MockerFixture
 
 
 @pytest.fixture()
@@ -49,3 +52,15 @@ def argv() -> Iterator[None]:
     yield
 
     sys.argv = current_argv
+
+
+@pytest.fixture()
+def sleep(mocker: MockerFixture) -> Iterator[Callable[[float], None]]:
+    now = 0.0
+    mocker.patch("time.time", side_effect=lambda: now)
+
+    def _sleep(secs: float) -> None:
+        nonlocal now
+        now += secs
+
+    yield _sleep

--- a/tests/ui/test_progress_bar.py
+++ b/tests/ui/test_progress_bar.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import time
-
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,6 +9,8 @@ from cleo.ui.progress_bar import ProgressBar
 
 
 if TYPE_CHECKING:
+    from typing import Callable
+
     from cleo.io.buffered_io import BufferedIO
 
 
@@ -486,16 +486,16 @@ def test_overwrite_multiple_progress_bars_with_section_outputs(
 
 
 def test_min_and_max_seconds_between_redraws(
-    ansi_bar: ProgressBar, ansi_io: BufferedIO
+    ansi_bar: ProgressBar, ansi_io: BufferedIO, sleep: Callable[[float], None]
 ) -> None:
     ansi_bar.min_seconds_between_redraws(0.5)
     ansi_bar.max_seconds_between_redraws(2 - 1)
 
     ansi_bar.start()
     ansi_bar.set_progress(1)
-    time.sleep(1)
+    sleep(1)
     ansi_bar.set_progress(2)
-    time.sleep(2)
+    sleep(2)
     ansi_bar.set_progress(3)
 
     output = [

--- a/tests/ui/test_progress_indicator.py
+++ b/tests/ui/test_progress_indicator.py
@@ -1,39 +1,39 @@
 from __future__ import annotations
 
-import time
-
 from typing import TYPE_CHECKING
 
 from cleo.ui.progress_indicator import ProgressIndicator
 
 
 if TYPE_CHECKING:
+    from typing import Callable
+
     from cleo.io.buffered_io import BufferedIO
 
 
-def test_default_indicator(ansi_io: BufferedIO) -> None:
+def test_default_indicator(ansi_io: BufferedIO, sleep: Callable[[float], None]) -> None:
     bar = ProgressIndicator(ansi_io)
     bar.start("Starting...")
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.set_message("Advancing...")
     bar.advance()
     bar.finish("Done...")
     bar.start("Starting Again...")
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
     bar.finish("Done Again...")
     bar.start("Starting Again...")
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
     bar.finish("Done Again...", reset_indicator=True)
 
@@ -68,29 +68,29 @@ def test_default_indicator(ansi_io: BufferedIO) -> None:
     assert expected == ansi_io.fetch_error()
 
 
-def test_explicit_format(ansi_io: BufferedIO) -> None:
+def test_explicit_format(ansi_io: BufferedIO, sleep: Callable[[float], None]) -> None:
     bar = ProgressIndicator(ansi_io, ProgressIndicator.NORMAL)
     bar.start("Starting...")
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
-    time.sleep(0.101)
+    sleep(0.101)
     bar.set_message("Advancing...")
     bar.advance()
     bar.finish("Done...")
     bar.start("Starting Again...")
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
     bar.finish("Done Again...")
     bar.start("Starting Again...")
-    time.sleep(0.101)
+    sleep(0.101)
     bar.advance()
     bar.finish("Done Again...", reset_indicator=True)
 


### PR DESCRIPTION
We had a few `time.sleep`'s to test advancing progress bars, but really slowed down our tests. This mocks `time.now` instead, reducing the test suite (on my machine) from ~5s to ~0.5s.
