### PR TITLE
misc: Removed deprecated `-A` option from fish completion (#366)

### DIFF
--- a/news/366.misc.md
+++ b/news/366.misc.md
@@ -1,0 +1,1 @@
+Removed deprecated `-A` option from fish completion

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -262,7 +262,7 @@ script. Consult your shells documentation for how to add such directives.
             cmds_opts += [
                 f"# {command_name}",
                 *[
-                    f"complete -c {script_name} -A "
+                    f"complete -c {script_name} "
                     f"-n '__fish_seen_subcommand_from {sanitize(command_name)}' "
                     f"-l {opt.name} -d '{sanitize(opt.description)}'"
                     for opt in sorted(cmd.definition.options, key=lambda o: o.name)

--- a/tests/commands/completion/fixtures/fish.txt
+++ b/tests/commands/completion/fixtures/fish.txt
@@ -26,15 +26,15 @@ complete -c script -f -n '__fish_my_function_no_subcommand' -a 'spaced command' 
 # command options
 
 # command:with:colons
-complete -c script -A -n '__fish_seen_subcommand_from command:with:colons' -l goodbye -d ''
+complete -c script -n '__fish_seen_subcommand_from command:with:colons' -l goodbye -d ''
 
 # hello
-complete -c script -A -n '__fish_seen_subcommand_from hello' -l dangerous-option -d 'This $hould be `escaped`.'
-complete -c script -A -n '__fish_seen_subcommand_from hello' -l option-without-description -d ''
+complete -c script -n '__fish_seen_subcommand_from hello' -l dangerous-option -d 'This $hould be `escaped`.'
+complete -c script -n '__fish_seen_subcommand_from hello' -l option-without-description -d ''
 
 # help
 
 # list
 
 # 'spaced command'
-complete -c script -A -n '__fish_seen_subcommand_from \'spaced command\'' -l goodbye -d ''
+complete -c script -n '__fish_seen_subcommand_from \'spaced command\'' -l goodbye -d ''


### PR DESCRIPTION
Fix for issue #366 

Would be nice if it could be combined with #358 

Thanks