### PR TITLE
Update application.py - Fixed running poetry --help

### DIFF
--- a/src/cleo/application.py
+++ b/src/cleo/application.py
@@ -367,8 +367,8 @@ class Application:
         name = self._get_command_name(io)
         if io.input.has_parameter_option(["--help", "-h"], True):
             if not name:
-                name = "help"
-                io.set_input(ArgvInput(["console", "help", self._default_command]))
+                name = "list"
+                io.set_input(ArgvInput(["console", self._default_command]))
             else:
                 self._want_helps = True
 


### PR DESCRIPTION
Running poetry --help was governo the behavior of poetry list --help instead of poetry list.  The error was fixed in a simple way, changing the value of the variable "name" to "list" and removing the "help" parameter when calling the "_get_command_name(io)" funcition, when io assumed the values "-h" or "--help", in lines 370-371. This is in response of Issue #8710.