### PR TITLE
Fix encoding warnings with PEP 597 enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 env:
-  PYTHONWARNDEFAULTENCODING: 'true'
+  PYTHONWARNDEFAULTENCODING: true
 
 jobs:
   Tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  PYTHONWARNDEFAULTENCODING: 'true'
+
 jobs:
   Tests:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}

--- a/news/398.misc.md
+++ b/news/398.misc.md
@@ -1,0 +1,1 @@
+Fix encoding warnings with PEP 597 enabled

--- a/src/cleo/ui/exception_trace/frame.py
+++ b/src/cleo/ui/exception_trace/frame.py
@@ -62,7 +62,7 @@ class Frame:
             return ""
         if self._filename not in type(self)._content_cache:
             try:
-                file_content = Path(self._filename).read_text()
+                file_content = Path(self._filename).read_text(encoding="utf-8")
             except OSError:
                 file_content = ""
             type(self)._content_cache[self._filename] = file_content

--- a/src/cleo/ui/question.py
+++ b/src/cleo/ui/question.py
@@ -265,7 +265,7 @@ class Question:
         return ret.strip()
 
     def _has_stty_available(self) -> bool:
-        with Path(os.devnull).open("w") as devnull:
+        with Path(os.devnull).open("w", encoding="utf-8") as devnull:
             try:
                 exit_code = subprocess.call(["stty"], stdout=devnull, stderr=devnull)
             except Exception:

--- a/tests/commands/completion/test_completions_command.py
+++ b/tests/commands/completion/test_completions_command.py
@@ -48,7 +48,10 @@ def test_bash(mocker: MockerFixture) -> None:
     tester = CommandTester(command)
     tester.execute("bash")
 
-    with open(os.path.join(os.path.dirname(__file__), "fixtures", "bash.txt")) as f:
+    with open(
+        os.path.join(os.path.dirname(__file__), "fixtures", "bash.txt"),
+        encoding="utf-8",
+    ) as f:
         expected = f.read()
 
     assert expected == tester.io.fetch_output().replace("\r\n", "\n")
@@ -70,7 +73,9 @@ def test_zsh(mocker: MockerFixture) -> None:
     tester = CommandTester(command)
     tester.execute("zsh")
 
-    with open(os.path.join(os.path.dirname(__file__), "fixtures", "zsh.txt")) as f:
+    with open(
+        os.path.join(os.path.dirname(__file__), "fixtures", "zsh.txt"), encoding="utf-8"
+    ) as f:
         expected = f.read()
 
     assert expected == tester.io.fetch_output().replace("\r\n", "\n")
@@ -92,7 +97,10 @@ def test_fish(mocker: MockerFixture) -> None:
     tester = CommandTester(command)
     tester.execute("fish")
 
-    with open(os.path.join(os.path.dirname(__file__), "fixtures", "fish.txt")) as f:
+    with open(
+        os.path.join(os.path.dirname(__file__), "fixtures", "fish.txt"),
+        encoding="utf-8",
+    ) as f:
         expected = f.read()
 
     assert expected == tester.io.fetch_output().replace("\r\n", "\n")

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -68,7 +68,9 @@ def test_long_version() -> None:
 
 
 def test_help(app: Application) -> None:
-    assert app.help == FIXTURES_PATH.joinpath("application_help.txt").read_text()
+    assert app.help == FIXTURES_PATH.joinpath("application_help.txt").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_all(app: Application) -> None:
@@ -218,10 +220,9 @@ def test_set_catch_exceptions(app: Application, environ: dict[str, str]) -> None
     tester.execute("foo", decorated=False)
 
     assert tester.io.fetch_output() == ""
-    assert (
-        tester.io.fetch_error()
-        == FIXTURES_PATH.joinpath("application_exception1.txt").read_text()
-    )
+    assert tester.io.fetch_error() == FIXTURES_PATH.joinpath(
+        "application_exception1.txt"
+    ).read_text(encoding="utf-8")
 
     app.catch_exceptions(False)
 
@@ -256,42 +257,37 @@ def test_run(app: Application, argv: list[str]) -> None:
 def test_run_runs_the_list_command_without_arguments(tester: ApplicationTester) -> None:
     tester.execute("", decorated=False)
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run1.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run1.txt"
+    ).read_text(encoding="utf-8")
 
 
 def test_run_runs_help_command_if_required(tester: ApplicationTester) -> None:
     tester.execute("--help", decorated=False)
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run2.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run2.txt"
+    ).read_text(encoding="utf-8")
 
     tester.execute("-h", decorated=False)
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run2.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run2.txt"
+    ).read_text(encoding="utf-8")
 
 
 def test_run_runs_help_command_with_command(tester: ApplicationTester) -> None:
     tester.execute("--help list", decorated=False)
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run3.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run3.txt"
+    ).read_text(encoding="utf-8")
 
     tester.execute("list -h", decorated=False)
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run3.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run3.txt"
+    ).read_text(encoding="utf-8")
 
 
 def test_run_removes_all_output_if_quiet(tester: ApplicationTester) -> None:
@@ -325,33 +321,29 @@ def test_run_with_verbosity(tester: ApplicationTester) -> None:
 def test_run_with_version(tester: ApplicationTester) -> None:
     tester.execute("--version")
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run4.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run4.txt"
+    ).read_text(encoding="utf-8")
 
     tester.execute("-V")
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run4.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run4.txt"
+    ).read_text(encoding="utf-8")
 
 
 def test_run_with_help(tester: ApplicationTester) -> None:
     tester.execute("help --help")
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run5.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run5.txt"
+    ).read_text(encoding="utf-8")
 
     tester.execute("-h help")
 
-    assert (
-        tester.io.fetch_output()
-        == FIXTURES_PATH.joinpath("application_run5.txt").read_text()
-    )
+    assert tester.io.fetch_output() == FIXTURES_PATH.joinpath(
+        "application_run5.txt"
+    ).read_text(encoding="utf-8")
 
 
 def test_run_with_input() -> None:

--- a/tests/ui/exception_trace/test_frame.py
+++ b/tests/ui/exception_trace/test_frame.py
@@ -22,7 +22,7 @@ def test_frame() -> None:
     assert frame.function == "test_frame"
     assert frame.line == "        simple_exception()\n"
 
-    with open(__file__) as f:
+    with open(__file__, encoding="utf-8") as f:
         assert f.read() == frame.file_content
 
     assert repr(frame) == f"<Frame {__file__}, test_frame, 12>"

--- a/tests/ui/test_question.py
+++ b/tests/ui/test_question.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 def has_tty_available() -> bool:
-    with open(os.devnull, "w") as devnull:
+    with open(os.devnull, "w", encoding="utf-8") as devnull:
         exit_code = subprocess.call(["stty", "2"], stdout=devnull, stderr=devnull)
 
     return exit_code == 0


### PR DESCRIPTION
This PR fixes Encoding Warnings with PEP 597 warnings enabled and enables the warnings in CI. It goes along with https://github.com/python-poetry/poetry/pull/8893 and https://github.com/python-poetry/poetry-core/pull/685.