### PR TITLE
Improve `cleo._utils` coverage

### DIFF
--- a/news/408.feat.md
+++ b/news/408.feat.md
@@ -1,0 +1,1 @@
+Improved coverage for `cleo._utils` module

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 
 from cleo._utils import find_similar_names
 from cleo._utils import format_time
+from cleo._utils import strip_tags
 
 
 @pytest.mark.parametrize(
@@ -39,3 +40,10 @@ def test_format_time(input_secs: float, expected: str) -> None:
 def test_find_similar_names(name: str, expected: list[str]) -> None:
     names = ["help", "foo1", "foo2", "bar1", "bar2", "foo bar1", "foo bar2"]
     assert find_similar_names(name, names) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected", (("<ab> cde</>", " cde"), ("<ab", "<ab"), ("cd>", "cd>"))
+)
+def test_strip_tags(value: str, expected: str) -> None:
+    assert strip_tags(value) == expected


### PR DESCRIPTION
For some reason, `strip_tags` didn't have tests, so I added one.