### PR TITLE
Do not quote spaced commands in ZSH

### DIFF
--- a/news/360.bugfix.md
+++ b/news/360.bugfix.md
@@ -1,0 +1,1 @@
+Disabled quoting multiple-word completion tokens in ZSH

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -234,14 +234,13 @@ script. Consult your shells documentation for how to add such directives.
         for cmd in sorted(self.application.all().values(), key=lambda c: c.name or ""):
             if cmd.hidden or not (cmd.enabled and cmd.name):
                 continue
-            command_name = shell_quote(cmd.name) if " " in cmd.name else cmd.name
-            cmds.append(self._zsh_describe(command_name, sanitize(cmd.description)))
+            cmds.append(self._zsh_describe(cmd.name, sanitize(cmd.description)))
             options = " ".join(
                 self._zsh_describe(f"--{opt.name}", sanitize(opt.description))
                 for opt in sorted(cmd.definition.options, key=lambda o: o.name)
             )
             cmds_opts += [
-                f"            ({command_name})",
+                f"            ({cmd.name})",
                 f"            opts+=({options})",
                 "            ;;",
                 "",  # newline

--- a/tests/commands/completion/fixtures/zsh.txt
+++ b/tests/commands/completion/fixtures/zsh.txt
@@ -21,7 +21,7 @@ _my_function()
         opts+=("--ansi:Force ANSI output." "--help:Display help for the given command. When no command is given display help for the list command." "--no-ansi:Disable ANSI output." "--no-interaction:Do not ask any interactive question." "--quiet:Do not output any message." "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug." "--version:Display this application version.")
     elif [[ $cur == $com ]]; then
         state="command"
-        coms+=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands." "'spaced command':Command with space in name.")
+        coms+=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands." "spaced command:Command with space in name.")
     fi
 
     case $state in
@@ -47,7 +47,7 @@ _my_function()
             opts+=()
             ;;
 
-            ('spaced command')
+            (spaced command)
             opts+=("--goodbye")
             ;;
 


### PR DESCRIPTION
It seems like quoting breaks completion in ZSH for multiple-word commands.

fixes #360 