### PR TITLE
feat: Added integration with the built-in logging package

### DIFF
--- a/src/cleo/io/output_handler.py
+++ b/src/cleo/io/output_handler.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+
+from typing import TYPE_CHECKING
+from typing import ClassVar
+
+
+if TYPE_CHECKING:
+    from cleo.io.outputs.output import Output
+
+
+class OutputHandler(logging.Handler):
+    """
+    A handler class which writes logging records, appropriately formatted,
+    to a Cleo output stream.
+    """
+
+    tags: ClassVar[dict[str, str]] = {
+        "CRITICAL": "<error>",
+        "ERROR": "<error>",
+        "WARNING": "<fg=yellow>",
+        "DEBUG": "<fg=dark_gray>",
+    }
+
+    def __init__(self, output: Output):
+        super().__init__()
+        self.output = output
+
+    def emit(self, record: logging.LogRecord):
+        """
+        Emit a record.
+
+        If a formatter is specified, it is used to format the record.
+        The record is then written to the output with a trailing newline.  If
+        exception information is present, it is formatted using
+        traceback.print_exception and appended to the stream.  If the stream
+        has an 'encoding' attribute, it is used to determine how to do the
+        output to the stream.
+        """
+        try:
+            msg = self.tags.get(record.levelname, "") + self.format(record) + "</>"
+            self.output.write(msg, new_line=True)
+
+        except Exception:
+            self.handleError(record)

--- a/tests/fixtures/foo4_command.py
+++ b/tests/fixtures/foo4_command.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+from typing import ClassVar
+
+from cleo.commands.command import Command
+
+
+def log_stuff():
+    logging.debug("This is an debug log record")
+    logging.info("This is an info log record")
+    logging.warning("This is an warning log record")
+    logging.error("This is an error log record")
+
+
+class Foo4Command(Command):
+    name = "foo4"
+
+    description = "The foo4 bar command"
+
+    aliases: ClassVar[list[str]] = ["foo4"]
+
+    def handle(self) -> int:
+        log_stuff()
+        return 0

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -17,6 +17,7 @@ from cleo.testers.application_tester import ApplicationTester
 from tests.fixtures.foo1_command import Foo1Command
 from tests.fixtures.foo2_command import Foo2Command
 from tests.fixtures.foo3_command import Foo3Command
+from tests.fixtures.foo4_command import Foo4Command
 from tests.fixtures.foo_command import FooCommand
 from tests.fixtures.foo_sub_namespaced1_command import FooSubNamespaced1Command
 from tests.fixtures.foo_sub_namespaced2_command import FooSubNamespaced2Command
@@ -380,3 +381,70 @@ def test_run_with_input_and_non_interactive(cmd: Command) -> None:
 
     assert status_code == 0
     assert tester.io.fetch_output() == "default input\n"
+
+
+@pytest.mark.parametrize("cmd", (Foo4Command(),))
+def test_run_with_logging_integration_normal(cmd: Command) -> None:
+    app = Application()
+
+    app.add(cmd)
+
+    tester = ApplicationTester(app)
+    status_code = tester.execute(f"{cmd.name}")
+
+    expected = "This is an warning log record\n" "This is an error log record\n"
+
+    assert status_code == 0
+    assert tester.io.fetch_output() == expected
+
+
+@pytest.mark.parametrize("cmd", (Foo4Command(),))
+def test_run_with_logging_integration_quiet(cmd: Command) -> None:
+    app = Application()
+
+    app.add(cmd)
+
+    tester = ApplicationTester(app)
+    status_code = tester.execute(f"{cmd.name} -q")
+
+    assert status_code == 0
+    assert tester.io.fetch_output() == ""
+
+
+@pytest.mark.parametrize("cmd", (Foo4Command(),))
+def test_run_with_logging_integration_verbose(cmd: Command) -> None:
+    app = Application()
+
+    app.add(cmd)
+
+    tester = ApplicationTester(app)
+    status_code = tester.execute(f"{cmd.name} -v")
+
+    expected = (
+        "This is an info log record\n"
+        "This is an warning log record\n"
+        "This is an error log record\n"
+    )
+
+    assert status_code == 0
+    assert tester.io.fetch_output() == expected
+
+
+@pytest.mark.parametrize("cmd", (Foo4Command(),))
+def test_run_with_logging_integration_very_verbose(cmd: Command) -> None:
+    app = Application()
+
+    app.add(cmd)
+
+    tester = ApplicationTester(app)
+    status_code = tester.execute(f"{cmd.name} -vv")
+
+    expected = (
+        "This is an debug log record\n"
+        "This is an info log record\n"
+        "This is an warning log record\n"
+        "This is an error log record\n"
+    )
+
+    assert status_code == 0
+    assert tester.io.fetch_output() == expected


### PR DESCRIPTION
This PR integrates the built-in `logging` package, as listed in the Cleo 3.0 writeup (#415 ). Implementation is of course subject to change, but I thought I'd get the ball rolling :)

Here's what I did:
- Added an OutputHandler class, allowing logging to emit `LogRecords` to a `cleo.io.outputs.output.Output`
- Added a method to `cleo.application.Application` which attaches an `OutputHandler` to the root logger, and configures it to have a log level that is coherent with Cleo's one.
- Added unit tests ensuring all this works as expected.

Here are some open points that I know we need to discuss:
- How should we map logging's log levels to Cleo's verbosity levels? Current implementation is as follows:
  - Quiet: CRITICAL (but nothing gets printed anyway so whatever)
  - Normal: WARNING
  - Verbose: INFO
  - Very verbose: DEBUG
  - Debug: DEBUG
- Formatting:
  - Should the stuff coming from the `logging` handler have some sort of prefix or something to distinguish them from what is coming directly from `output.write_line()`?
  - The formatter styles for error, warning, info and debug need to be defined.