### PR TITLE
Update macos image used in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           - os: Windows
             image: windows-2022
           - os: macOS
-            image: macos-12
+            image: macos-14
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Old `macos-12` is [deprecated](https://github.com/actions/runner-images/issues/10721).