### PR TITLE
Add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, macOS, Windows]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: Ubuntu
             image: ubuntu-22.04
@@ -42,6 +42,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
+          allow-prereleases: 'true'
 
       - name: Install dependencies
         run: poetry install

--- a/news/506.feat.md
+++ b/news/506.feat.md
@@ -1,0 +1,1 @@
+Add support for Python 3.14.


### PR DESCRIPTION
Since Python 3.14 is coming out soon, let's add it to the test matrix.