### PR TITLE
Fix parameter_option returning only the first character of attached values

### DIFF
--- a/news/434.bugfix.md
+++ b/news/434.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `parameter_option` returning only the first character of `--option=value` and attached short-option values.

--- a/src/cleo/io/inputs/argv_input.py
+++ b/src/cleo/io/inputs/argv_input.py
@@ -129,8 +129,8 @@ class ArgvInput(Input):
                 # For short options, test for '-o' at beginning
                 leading = value + "=" if value.startswith("--") else value
 
-                if token == value or (leading != "" and token.startswith(leading)):
-                    return token[len(leading)]
+                if leading != "" and token.startswith(leading):
+                    return token[len(leading) :]
 
         return False
 

--- a/tests/io/inputs/test_argv_input.py
+++ b/tests/io/inputs/test_argv_input.py
@@ -153,7 +153,6 @@ def test_parse_options(
     assert i.options == expected_options
 
 
-
 @pytest.mark.parametrize(
     ["args", "values", "expected"],
     [
@@ -161,7 +160,11 @@ def test_parse_options(
         (["cli.py", "--directory=/tmp/foo"], "--directory", "/tmp/foo"),
         (["cli.py", "-C", "/tmp/foo"], "-C", "/tmp/foo"),
         (["cli.py", "-C/tmp/foo"], "-C", "/tmp/foo"),
-        (["cli.py", "run", "--directory=/tmp/foo", "python"], "--directory", "/tmp/foo"),
+        (
+            ["cli.py", "run", "--directory=/tmp/foo", "python"],
+            "--directory",
+            "/tmp/foo",
+        ),
         (["cli.py", "run", "-C/tmp/foo", "python"], "-C", "/tmp/foo"),
     ],
 )

--- a/tests/io/inputs/test_argv_input.py
+++ b/tests/io/inputs/test_argv_input.py
@@ -151,3 +151,23 @@ def test_parse_options(
     i.bind(Definition(options))
 
     assert i.options == expected_options
+
+
+
+@pytest.mark.parametrize(
+    ["args", "values", "expected"],
+    [
+        (["cli.py", "--directory", "/tmp/foo"], "--directory", "/tmp/foo"),
+        (["cli.py", "--directory=/tmp/foo"], "--directory", "/tmp/foo"),
+        (["cli.py", "-C", "/tmp/foo"], "-C", "/tmp/foo"),
+        (["cli.py", "-C/tmp/foo"], "-C", "/tmp/foo"),
+        (["cli.py", "run", "--directory=/tmp/foo", "python"], "--directory", "/tmp/foo"),
+        (["cli.py", "run", "-C/tmp/foo", "python"], "-C", "/tmp/foo"),
+    ],
+)
+def test_parameter_option_returns_full_attached_value(
+    args: list[str], values: str, expected: str
+) -> None:
+    i = ArgvInput(args)
+
+    assert i.parameter_option(values) == expected


### PR DESCRIPTION
Fixes #434.

`ArgvInput.parameter_option()` treated an attached value as a single character:

```python
return token[len(leading)]
```

So `--directory=/tmp/foo` became `/` and `-C/tmp/foo` became `/`. Space-separated forms (`--directory /tmp/foo`) already worked because they take the next token.

This is the same slice Symfony uses (`substr($token, strlen($leading))`). Poetry reads `--directory` / `-C` through this helper before the command is fully parsed, which is why `poetry run --directory=path python file.py` failed while `poetry run --directory path python file.py` succeeded.

## Test plan
- [x] `pytest tests/io/inputs/test_argv_input.py` (covers `--option=value`, `-Ovalue`, space-separated forms, and `run --directory=path`)
- [x] Full `pytest tests` (one pre-existing TTY decoration failure unrelated to this change)