### PR TITLE
docs: import Command and Application from where they live

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -6,7 +6,7 @@ create ``greet_command.py`` and add the following to it:
 
 .. code-block:: python
 
-    from cleo import Command
+    from cleo.commands.command import Command
 
 
     class GreetCommand(Command):
@@ -40,7 +40,7 @@ an ``Application`` and adds commands to it:
     #!/usr/bin/env python
 
     from greet_command import GreetCommand
-    from cleo import Application
+    from cleo.application import Application
 
     application = Application()
     application.add(GreetCommand())
@@ -406,7 +406,7 @@ console:
 
     import pytest
 
-    from cleo import Application
+    from cleo.application import Application
     from cleo.testers.command_tester import CommandTester
 
     def test_execute(self):
@@ -430,7 +430,7 @@ as a string to the ``CommandTester.execute()`` method:
 
     import pytest
 
-    from cleo import Application
+    from cleo.application import Application
     from cleo.testers.command_tester import CommandTester
 
     def test_execute(self):

--- a/docs/single_command_tool.rst
+++ b/docs/single_command_tool.rst
@@ -7,7 +7,7 @@ it is possible to remove this need by using `default()` when adding a command:
 
 .. code-block:: python
 
-    from cleo import Application
+    from cleo.application import Application
 
     command = GreetCommand()
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,7 +14,7 @@ built-in options as well as a couple of built-in commands for Cleo.
         #!/usr/bin/env python
         # application.py
 
-        from cleo import Application
+        from cleo.application import Application
 
         application = Application()
         # ...

--- a/news/539.docs.md
+++ b/news/539.docs.md
@@ -1,0 +1,1 @@
+Corrected the example imports in the documentation: `Command` and `Application` are imported from `cleo.commands.command` and `cleo.application`.


### PR DESCRIPTION
`src/cleo/__init__.py` defines only `__version__` and exports nothing, so every documented example fails on its first line:

```python
>>> from cleo import Command
ImportError: cannot import name 'Command' from 'cleo'
```

That includes the **first code block in the introduction**, the one a new user copies before anything else works.

## Six occurrences, three documents

| file | line | was |
|---|---|---|
| `docs/introduction.rst` | 9 | `from cleo import Command` |
| `docs/introduction.rst` | 43, 409, 433 | `from cleo import Application` |
| `docs/single_command_tool.rst` | 10 | `from cleo import Application` |
| `docs/usage.rst` | 17 | `from cleo import Application` |

## Corrected to the paths the project's own tests use

```python
from cleo.commands.command import Command
from cleo.application import Application
```

Both were executed against this tree before pushing: the old import raises, the new ones resolve.

Found with [docproof](https://github.com/melbinjp/docproof), which checks documentation claims against the code. It flagged `cleo.Command` as not defined, imported, or re-exported anywhere in `cleo`; the other five turned up when I went looking for the same shape.

