### PR TITLE
docs: add missing period to tokenize docstring

### DIFF
--- a/src/cleo/helpers.py
+++ b/src/cleo/helpers.py
@@ -44,7 +44,7 @@ def option(
 
 def tokenize(string: str) -> list[str]:  # pragma: no cover
     """
-    Split the string using shell-like syntax. Maps directly to using `shlex.split`
+    Split the string using shell-like syntax. Maps directly to using `shlex.split`.
     """
     import shlex
 


### PR DESCRIPTION
### Summary
- Add missing trailing period in `tokenize` docstring in `src/cleo/helpers.py`.