### PR TITLE
fix: apply column max widths when rendering tables (#88)

### DIFF
--- a/news/88.bugfix.md
+++ b/news/88.bugfix.md
@@ -1,0 +1,1 @@
+Fix `Table.set_column_max_width()` having no effect on rendered tables

--- a/src/cleo/ui/table.py
+++ b/src/cleo/ui/table.py
@@ -104,7 +104,7 @@ class Table:
         return self
 
     def set_column_max_width(self, column_index: int, width: int) -> Table:
-        self._column_widths[column_index] = width
+        self._column_max_widths[column_index] = width
 
         return self
 
@@ -426,8 +426,10 @@ class Table:
                 if column in self._column_max_widths and self._column_max_widths[
                     column
                 ] < len(self._io.remove_format(cell)):
-                    assert isinstance(self._io, Output)
-                    cell = self._io.formatter.format_and_wrap(
+                    output = (
+                        self._io if isinstance(self._io, Output) else self._io.output
+                    )
+                    cell = output.formatter.format_and_wrap(
                         cell, self._column_max_widths[column] * colspan
                     )
 

--- a/tests/ui/test_table.py
+++ b/tests/ui/test_table.py
@@ -481,3 +481,46 @@ def test_style_for_side_effects(io: BufferedIO) -> None:
     output2 = io.fetch_output()
 
     assert output1 != output2
+
+
+def test_column_max_width_wraps_long_cells(io: BufferedIO) -> None:
+    table = Table(io)
+    table.set_headers(["ISBN", "Description"])
+    table.set_rows(
+        [["99921-58-10-7", "A long description that has to be wrapped to fit"]]
+    )
+    table.set_column_max_width(1, 12)
+
+    table.render()
+
+    expected = """\
++---------------+--------------+
+| ISBN          | Description  |
++---------------+--------------+
+| 99921-58-10-7 | A long descr |
+|               | iption that  |
+|               | has to be wr |
+|               | apped to fit |
++---------------+--------------+
+"""
+
+    assert io.fetch_output() == expected
+
+
+def test_column_max_width_does_not_widen_short_cells(io: BufferedIO) -> None:
+    table = Table(io)
+    table.set_headers(["ISBN", "Title"])
+    table.set_rows([["99921-58-10-7", "Divine Comedy"]])
+    table.set_column_max_width(1, 40)
+
+    table.render()
+
+    expected = """\
++---------------+---------------+
+| ISBN          | Title         |
++---------------+---------------+
+| 99921-58-10-7 | Divine Comedy |
++---------------+---------------+
+"""
+
+    assert io.fetch_output() == expected


### PR DESCRIPTION
## Summary

- `Table.set_column_max_width()` wrote to `_column_widths` instead of `_column_max_widths`. Nothing else ever writes `_column_max_widths`, so the max-width and cell-wrapping code in `_build_table_rows()` was unreachable and setting a max width did nothing.
- It was worse than a no-op: `_get_cell_width()` folds `_column_widths` in with `max()`, so the value actually acted as a *minimum* width — `set_column_max_width(0, 20)` padded a 2-character column out to 20, the inverse of the method name.
- Making the branch reachable revealed a second latent defect. It asserted `self._io` is an `Output`, but `Table` is typed `io: IO | Output` and `Command.table()` passes an `IO`, which has no `formatter` property — so wrapping raised `AssertionError` for the common entry point. That assert had only ever satisfied mypy; it had never actually run.

## Changes

- `src/cleo/ui/table.py`: `set_column_max_width()` now writes `_column_max_widths`; the wrapping branch resolves the formatter from either an `IO` or an `Output`, mirroring how `IO.remove_format()` delegates.
- `tests/ui/test_table.py`: added `test_column_max_width_wraps_long_cells` (a long cell is capped and wrapped) and `test_column_max_width_does_not_widen_short_cells` (a max width must not pad a narrow column). Both fail on `main`.
- `news/88.bugfix.md`: news fragment.

I left `_cleanup()` alone on purpose — it resets `_column_widths`, but Symfony's `Table::cleanup()`, which this ports, resets neither. Happy to change that if you'd prefer both setters behave the same way.

## Scope

Refs #88. To be precise about what this does and does not do: the literal `ValueError` from that 2020 report is already gone, since it came from stdlib `textwrap`, which no longer appears anywhere in cleo. What is still broken is that issue's own option C — cleo has the machinery to shrink a too-wide table, it just never runs. This makes it run. It does not add automatic fitting to terminal width (option A); a caller still has to set a max width explicitly. Leaving the issue open for that reason rather than auto-closing it.