### PR TITLE
fix: bind the called command's own arguments in call()/call_silent()

### DIFF
--- a/news/130.bugfix.md
+++ b/news/130.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `Command.call()` and `Command.call_silent()` misbinding arguments to the called command.

--- a/src/cleo/commands/command.py
+++ b/src/cleo/commands/command.py
@@ -93,7 +93,8 @@ class Command:
         command = self.application.get(name)
 
         return self.application._run_command(
-            command, self._io.with_input(StringInput(args or ""))
+            command,
+            self._io.with_input(StringInput(f"{name} {args}" if args else name)),
         )
 
     def call_silent(self, name: str, args: str | None = None) -> int:
@@ -103,7 +104,9 @@ class Command:
         assert self.application is not None
         command = self.application.get(name)
 
-        return self.application._run_command(command, NullIO(StringInput(args or "")))
+        return self.application._run_command(
+            command, NullIO(StringInput(f"{name} {args}" if args else name))
+        )
 
     def argument(self, name: str) -> Any:
         """

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from cleo.application import Application
 from cleo.commands.command import Command
 from cleo.helpers import argument
+from cleo.testers.application_tester import ApplicationTester
 from cleo.testers.command_tester import CommandTester
 from tests.fixtures.inherited_command import ChildCommand
 from tests.fixtures.signature_command import SignatureCommand
@@ -87,3 +88,54 @@ def test_explicit_multiple_argument() -> None:
     tester.execute("1 2 3")
 
     assert tester.io.fetch_output() == "1,2,3\n"
+
+
+class CalleeCommand(Command):
+    name = "callee"
+    arguments: ClassVar[list[Argument]] = [argument("value", "The value to print.")]
+
+    def handle(self) -> int:
+        self.line(self.argument("value"))
+        return 0
+
+
+class CallerCommand(Command):
+    name = "caller"
+
+    def handle(self) -> int:
+        return self.call("callee", "hello")
+
+
+class SilentCallerCommand(Command):
+    name = "silent-caller"
+
+    def handle(self) -> int:
+        return self.call_silent("callee", "hello")
+
+
+def _app_with_callee_and(caller: Command) -> Application:
+    application = Application()
+    application.add(CalleeCommand())
+    application.add(caller)
+
+    return application
+
+
+def test_call_binds_arguments_to_the_called_command() -> None:
+    # Regression test for https://github.com/python-poetry/cleo/issues/130: the
+    # application's own top-level "command" argument used to be first in line for
+    # binding, so the called command's first real argument was silently swallowed
+    # by that phantom slot instead of reaching the called command's own argument.
+    tester = ApplicationTester(_app_with_callee_and(CallerCommand()))
+
+    assert tester.execute("caller") == 0
+    assert tester.io.fetch_output() == "hello\n"
+
+
+def test_call_silent_binds_arguments_to_the_called_command() -> None:
+    tester = ApplicationTester(_app_with_callee_and(SilentCallerCommand()))
+
+    assert tester.execute("silent-caller") == 0
+    # call_silent runs the called command against a NullIO, so its own output
+    # isn't captured here -- the point of this test is that the call above didn't
+    # raise "Not enough arguments" and returned a successful status code.


### PR DESCRIPTION
Fixes #130.

## Root cause

`Command.call()`/`call_silent()` build a `StringInput` from just the raw `args` string and bind it against `self.definition`. After `merge_application_definition()` runs (which `run()` always calls first), `self.definition` returns `self._full_definition`, whose arguments are `set_arguments(self._application.definition.arguments)` **then** `add_arguments(self._definition.arguments)` — i.e. the Application's own top-level `"command"` positional argument comes first, followed by the called command's own arguments.

So `self.call("foo", "baz")` builds `StringInput("baz")`, and when that binds against a definition starting with the phantom `"command"` slot, `"baz"` gets consumed by that slot instead of reaching `foo`'s own `baz` argument — producing `Not enough arguments (missing: "baz")`. `call_silent` hits the same issue, surfacing as an `AttributeError` inside `NullIO` instead (per the traceback in the issue).

I verified this by reading `Command.call()`, `Command.run()`, and `merge_application_definition()` directly (see `src/cleo/commands/command.py`).

## Fix

Prepend the command name as the first token — exactly what a user would type at the actual command line (`python app.py foo baz`) — so it fills the `"command"` slot and the remaining tokens correctly bind to the called command's own argument definition.

## Testing

- Added `test_call_binds_arguments_to_the_called_command` and `test_call_silent_binds_arguments_to_the_called_command` to `tests/commands/test_command.py`, using `ApplicationTester` with a caller/callee command pair that mirrors the issue's exact repro.
- Verified both new tests fail without the fix (`Not enough arguments` / non-zero exit) and pass with it restored (via `git stash` on `command.py` alone).
- Full suite: `pytest tests/` → 248 passed, 4 skipped, no regressions.
- `ruff check` and `ruff format --check` are clean; `mypy src/cleo/commands/command.py` reports no issues.
- Added `news/130.bugfix.md` per CONTRIBUTING.md's news-fragment convention.