### PR TITLE
Fix progress bar remaining time calculation

### DIFF
--- a/news/544.bugfix.md
+++ b/news/544.bugfix.md
@@ -1,0 +1,1 @@
+Fixed the progress bar remaining-time placeholder to account for uncompleted steps.

--- a/src/cleo/ui/progress_bar.py
+++ b/src/cleo/ui/progress_bar.py
@@ -377,7 +377,7 @@ class ProgressBar(Component):
             remaining = 0
         else:
             remaining = round(
-                (time.time() - self._start_time) / self._step * (self._max - self._max)
+                (time.time() - self._start_time) / self._step * (self._max - self._step)
             )
 
         return format_time(remaining)

--- a/tests/ui/test_progress_bar.py
+++ b/tests/ui/test_progress_bar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -223,6 +224,15 @@ def test_percent(ansi_io: BufferedIO) -> None:
     expected = generate_output(output)
 
     assert expected == ansi_io.fetch_error()
+
+
+def test_remaining_time_uses_uncompleted_steps(ansi_io: BufferedIO) -> None:
+    with patch("cleo.ui.progress_bar.time.time", return_value=10):
+        bar = ProgressBar(ansi_io, max=10, min_seconds_between_redraws=0)
+        bar._start_time = 0
+        bar._step = 2
+
+        assert bar._formatter_remaining() == "40 secs"
 
 
 def test_overwrite_with_shorter_line(ansi_io: BufferedIO) -> None:


### PR DESCRIPTION
## Problem

The custom ProgressBar remaining-time placeholder always reports less than one second after progress begins. For a bar with 10 total steps, 2 completed steps, and 10 seconds elapsed, it reports "< 1 sec" even though 40 seconds remain.

## Fix

Use the number of uncompleted steps when estimating the remaining time. This makes remaining equal to estimated completion time minus elapsed time.

## Tests

- `poetry run pytest tests/ui/test_progress_bar.py -k remaining` - passed (1 passed, 25 deselected)
- `poetry run pytest` - passed (248 passed, 3 skipped)
- `poetry run pre-commit run --all-files` - passed
- `poetry run mypy` - passed
- `towncrier check --compare-with origin/main` - passed

## Compatibility

This changes only the documented custom remaining-time calculation. The normal and verbose built-in formats do not use the remaining placeholder.

## Related issue

Independent reproduction; no matching open issue or pull request was found.

The required `news/544.bugfix.md` fragment is included.
